### PR TITLE
Format V files

### DIFF
--- a/examples/call_js_from_v.v
+++ b/examples/call_js_from_v.v
@@ -1,20 +1,20 @@
 import vwebui as webui
 
 fn my_function_count(e &webui.Event) webui.Response {
-  count := e.window.script("return count;", 0, 48)
-  e.window.script("SetCount(${count.int() + 1});", 0, 0)
-  return 0
+	count := e.window.script('return count;', 0, 48)
+	e.window.script('SetCount(${count.int() + 1});', 0, 0)
+	return 0
 }
 
 fn my_function_exit(e &webui.Event) webui.Response { // Close all opened windows
-    webui.exit()
-    return 0
+	webui.exit()
+	return 0
 }
 
 mut my_window := webui.new_window() // Create a window
 
 // UI HTML
-my_html := ('
+my_html := '
 <html>
   <head>
     <title>Call JavaScript from V Example</title>
@@ -50,15 +50,15 @@ my_html := ('
       }
     </script>
   </body>
-</html>')
+</html>'
 
 // Bind HTML elements with functions
-my_window.bind("MyButton1", my_function_count)
-my_window.bind("MyButton2", my_function_exit)
+my_window.bind('MyButton1', my_function_count)
+my_window.bind('MyButton2', my_function_exit)
 
 // Show the window
 if !my_window.show(my_html) { // Run the window
-    panic("The browser(s) was failed") // If not, print a error info
+	panic('The browser(s) was failed') // If not, print a error info
 }
 
 // Wait until all windows get closed

--- a/examples/call_v_from_js.v
+++ b/examples/call_v_from_js.v
@@ -1,49 +1,49 @@
 import vwebui as webui
 
 fn my_function_string(e &webui.Event) webui.Response {
-    // JavaScript:
-    // webui_fn('MyID_One', 'Hello');
+	// JavaScript:
+	// webui_fn('MyID_One', 'Hello');
 
-    response := e.data.string
-    println("my_function_string: ${response}") // Hello
+	response := e.data.string
+	println('my_function_string: ${response}') // Hello
 
-    // Need Multiple Arguments?
-    //
-    // WebUI support only one argument. To get multiple arguments
-    // you can send a JSON string from JavaScript then decode it.
-    return 0
+	// Need Multiple Arguments?
+	//
+	// WebUI support only one argument. To get multiple arguments
+	// you can send a JSON string from JavaScript then decode it.
+	return 0
 }
 
 fn my_function_integer(e &webui.Event) webui.Response {
-    // JavaScript:
-    // webui_fn('MyID_Two', 123456789);
+	// JavaScript:
+	// webui_fn('MyID_Two', 123456789);
 
-    response := e.data.int
-    println("my_function_integer: ${response}") // 123456789
-    return 0
+	response := e.data.int
+	println('my_function_integer: ${response}') // 123456789
+	return 0
 }
 
 fn my_function_boolean(e &webui.Event) webui.Response {
-    // JavaScript:
-    // webui_fn('MyID_Three', true);
+	// JavaScript:
+	// webui_fn('MyID_Three', true);
 
-    response := e.data.bool
-    println("my_function_boolean: ${response}") // true
-    return 0
+	response := e.data.bool
+	println('my_function_boolean: ${response}') // true
+	return 0
 }
 
 fn my_function_with_response(e &webui.Event) webui.Response {
-    // JavaScript:
-    // const result = webui_fn('MyID_Four', number);
+	// JavaScript:
+	// const result = webui_fn('MyID_Four', number);
 
-    number := e.data.int * 2
-    println("my_function_with_response: ${number}")
-    return number 
+	number := e.data.int * 2
+	println('my_function_with_response: ${number}')
+	return number
 }
 
 mut my_window := webui.new_window() // Create a window
 
-my_html := ('
+my_html := '
 <html>
   <head>
     <title>Call V from JavaScript Example</title>
@@ -86,16 +86,16 @@ my_html := ('
       }
     </script>
   </body>
-</html>')
+</html>'
 
 if !my_window.show(my_html) { // Run the window
-    panic("The browser(s) was failed") // If not, print a error info
+	panic('The browser(s) was failed') // If not, print a error info
 }
 
-my_window.bind("MyID_One", my_function_string)
-		.bind("MyID_Two", my_function_integer)
-		.bind("MyID_Three", my_function_boolean)
-		.bind("MyID_Four", my_function_with_response)
+my_window.bind('MyID_One', my_function_string)
+	.bind('MyID_Two', my_function_integer)
+	.bind('MyID_Three', my_function_boolean)
+	.bind('MyID_Four', my_function_with_response)
 
 // Wait until all windows get closed
 webui.wait()

--- a/examples/hello_world.v
+++ b/examples/hello_world.v
@@ -1,26 +1,27 @@
 import vwebui as webui
 
 fn check_the_password(e &webui.Event) webui.Response { // Check the password function
-    password := e.window.script("return document.getElementById(\"MyInput\").value;", 0, 4096)
-    println("Password: "+password)
-    
-    if password == "123456" { // Check the password
-        e.window.run("alert('Good. Password is correct.');") // Correct password
-    } else {
-        e.window.run("alert('Sorry. Wrong password.');") // Wrong password
-    }
-    return 0
+	password := e.window.script('return document.getElementById("MyInput").value;', 0,
+		4096)
+	println('Password: ' + password)
+
+	if password == '123456' { // Check the password
+		e.window.run("alert('Good. Password is correct.');") // Correct password
+	} else {
+		e.window.run("alert('Sorry. Wrong password.');") // Wrong password
+	}
+	return 0
 }
 
 fn close_the_application(e &webui.Event) webui.Response { // Close all opened windows
-    webui.exit()
-    return 0
+	webui.exit()
+	return 0
 }
 
 mut my_window := webui.new_window() // Create a window
 
 // UI HTML
-my_html := ('
+my_html := '
     <!DOCTYPE html>
     <html><head><title>WebUI 2 - V Example</title>
     <style>body{color: white; background: #0F2027;
@@ -28,18 +29,18 @@ my_html := ('
     background: linear-gradient(to right, #2C5364, #203A43, #0F2027);
     text-align:center; font-size: 18px; font-family: sans-serif;}</style></head><body>
     <h1>WebUI 2 - V Example</h1><br>
-    <input type=\"password\" id=\"MyInput\"><br><br>
-    <button id=\"MyButton1\">Check Password</button> - <button id=\"MyButton2\">Exit</button>
+    <input type="password" id="MyInput"><br><br>
+    <button id="MyButton1">Check Password</button> - <button id="MyButton2">Exit</button>
     </body></html>
-')
+'
 
 // Bind HTML elements with functions
-my_window.bind("MyButton1", check_the_password)
-my_window.bind("MyButton2", close_the_application)
+my_window.bind('MyButton1', check_the_password)
+my_window.bind('MyButton2', close_the_application)
 
 // Show the window
 if !my_window.show(my_html) { // Run the window
-    panic("The browser(s) was failed") // If not, print a error info
+	panic('The browser(s) was failed') // If not, print a error info
 }
 
 // Wait until all windows get closed

--- a/examples/kiosk.v
+++ b/examples/kiosk.v
@@ -2,5 +2,5 @@ import vwebui as webui
 
 mut my_window := webui.new_window()
 my_window.set_kiosk(true)
-my_window.show("<html>A kiosk example</html>")
+my_window.show('<html>A kiosk example</html>')
 webui.wait()

--- a/examples/minimal.v
+++ b/examples/minimal.v
@@ -1,5 +1,5 @@
 import vwebui as webui
 
 mut my_window := webui.new_window()
-my_window.show("<html>Hello</html>")
+my_window.show('<html>Hello</html>')
 webui.wait()

--- a/examples/serve_a_folder/serve_a_folder.v
+++ b/examples/serve_a_folder/serve_a_folder.v
@@ -1,54 +1,54 @@
 import vwebui as webui
 
 const (
-    my_window = 1
-    my_second_window = 2
+	my_window        = 1
+	my_second_window = 2
 )
 
 fn events(e &webui.Event) webui.Response { // Close all opened windows
-    // This function gets called every time
-    // there is an event
-    if e.event_type == .connected {
-        println("Connected.")
-    } else if e.event_type == .disconnected {
-        println("Disconnected.")
-    } else if e.event_type == .mouse_click {
-        println("Click.")
-    } else if e.event_type == .navigation {
-        println("Starting navigation to: ${e.data}")
-    }
-    return 0
+	// This function gets called every time
+	// there is an event
+	if e.event_type == .connected {
+		println('Connected.')
+	} else if e.event_type == .disconnected {
+		println('Disconnected.')
+	} else if e.event_type == .mouse_click {
+		println('Click.')
+	} else if e.event_type == .navigation {
+		println('Starting navigation to: ${e.data}')
+	}
+	return 0
 }
 
 fn switch_to_second_page(e &webui.Event) webui.Response {
-    // This function gets called every
-    // time the user clicks on "SwitchToSecondPage"
-    // Switch to `/second.html` in the same opened window.
-    e.window.show("second.html")
-    return 0
+	// This function gets called every
+	// time the user clicks on "SwitchToSecondPage"
+	// Switch to `/second.html` in the same opened window.
+	e.window.show('second.html')
+	return 0
 }
 
 fn show_second_window(e &webui.Event) webui.Response {
-    webui.get_window(my_second_window)
-        .show("second.html")
-    return 0
+	webui.get_window(my_second_window)
+		.show('second.html')
+	return 0
 }
 
 fn exit_app(e &webui.Event) webui.Response { // Close all opened windows
-    webui.exit()
-    return 0
+	webui.exit()
+	return 0
 }
 
 // Create new windows
+
 webui.new_window_by_id(my_window)
-    // Bind HTML element IDs with a C functions
-    .bind("SwitchToSecondPage", switch_to_second_page)
-    .bind("OpenNewWindow", show_second_window)
-    .bind("Exit", exit_app)
-    .bind("", events) // Bind events
-    .show("index.html") // Show a new window
+	.bind('SwitchToSecondPage', switch_to_second_page)
+	.bind('OpenNewWindow', show_second_window)
+	.bind('Exit', exit_app)
+	.bind('', events) // Bind events
+	.show('index.html') // Show a new window
 
 webui.new_window_by_id(my_second_window)
-    .bind("Exit", exit_app)
+	.bind('Exit', exit_app)
 
 webui.wait() // Wait until all windows get closed

--- a/examples/text-editor/text-editor.v
+++ b/examples/text-editor/text-editor.v
@@ -9,27 +9,30 @@ fn close(e &webui.Event) webui.Response {
 }
 
 fn open(e &webui.Event) webui.Response {
-	if e.data.string == "" {
+	if e.data.string == '' {
 		e.window.run("webui_fn('Open', prompt`File Location`)")
 		return 0
-	} else if e.data.string == "null" {
+	} else if e.data.string == 'null' {
 		return 0
 	}
 	file := e.data.string
-	if file != "" {
-		file_content :=os.read_file(file) or { println("Failed to read file: ${file}") ""}
+	if file != '' {
+		file_content := os.read_file(file) or {
+			println('Failed to read file: ${file}')
+			''
+		}
 
 		encoded_file := base64.encode_str(file)
 		encoded_file_content := base64.encode_str(file_content)
-		e.window.run("SetFile`${encoded_file}`")
-		e.window.run("addText`${encoded_file_content}`")
-		e.window.run("window.opened_file = `${file}`")
+		e.window.run('SetFile`${encoded_file}`')
+		e.window.run('addText`${encoded_file_content}`')
+		e.window.run('window.opened_file = `${file}`')
 	}
 	return 0
 }
 
 struct Save {
-	file string
+	file    string
 	content string
 }
 
@@ -44,9 +47,9 @@ fn save(e &webui.Event) webui.Response {
 
 main_window := webui.new_window()
 
-main_window.bind("Open", open)
-	.bind("Save", save)
-	.bind("Close", close)
-	.show("ui/MainWindow.html")
+main_window.bind('Open', open)
+	.bind('Save', save)
+	.bind('Close', close)
+	.show('ui/MainWindow.html')
 
 webui.wait()

--- a/vwebui.v
+++ b/vwebui.v
@@ -1,12 +1,12 @@
-[translated]
 /*
-  V-WebUI 2.3.0
-  https://github.com/malisipi/vwebui
-  Copyright (c) 2023 Mehmet Ali.
-  Licensed under MIT License.
-  All rights reserved.
+V-WebUI 2.3.0
+https://github.com/malisipi/vwebui
+Copyright (c) 2023 Mehmet Ali.
+Licensed under MIT License.
+All rights reserved.
 */
 
+[translated]
 module vwebui
 
 // WebUI Core
@@ -23,7 +23,7 @@ $if tinyc {
 	#flag windows -DWEBUI_NO_TLHELPER32
 }
 // Debug
-$if webui_log? {
+$if webui_log ? {
 	#flag -DWEBUI_LOG
 }
 
@@ -65,25 +65,29 @@ pub enum runtime as u64 {
 // Typedefs of struct
 
 pub type Window = u64
+
 pub struct C.webui_event_t {
-	pub mut:
-		window			Window // Pointer to the window object
-		event_type		u64 // Event type
-		element			&char // HTML element ID
-		data			&char // JavaScript data
-		event_number	u64 // To set the callback response
+pub mut:
+	window       Window // Pointer to the window object
+	event_type   u64    // Event type
+	element      &char  // HTML element ID
+	data         &char  // JavaScript data
+	event_number u64    // To set the callback response
 }
+
 pub type CEvent = C.webui_event_t
-pub type CFunction = fn(e &CEvent)
+pub type CFunction = fn (e &CEvent)
+
 pub struct Event {
-	pub mut:
-		window			Window // Pointer to the window object
-		event_type		event // Event type
-		element			string // HTML element ID
-		data			WebuiResponseData // JavaScript data
-		event_number	u64 // To set the callback response
+pub mut:
+	window       Window // Pointer to the window object
+	event_type   event  // Event type
+	element      string // HTML element ID
+	data         WebuiResponseData // JavaScript data
+	event_number u64 // To set the callback response
 }
-pub type Function = fn(e &Event) Response
+
+pub type Function = fn (e &Event) Response
 
 // C Functions
 
@@ -117,40 +121,44 @@ fn C.webui_get_new_window_id() u64
 
 // V Interface
 
-pub fn (window Window) script (javascript string, timeout u64, size_buffer int) string {
-	response := &char(" ".repeat(size_buffer).str)
-    C.webui_script(window, &char(javascript.str), timeout, response, size_buffer)
+pub fn (window Window) script(javascript string, timeout u64, size_buffer int) string {
+	response := &char(' '.repeat(size_buffer).str)
+	C.webui_script(window, &char(javascript.str), timeout, response, size_buffer)
 	return unsafe { response.vstring() }
 }
 
 // Get
 struct WebuiResponseData {
 pub mut:
-	string	string
-	int		int
-	bool	bool
+	string string
+	int    int
+	bool   bool
 }
-pub fn (e &CEvent) get () WebuiResponseData {
-    str := unsafe { cstring_to_vstring(C.webui_get_string(e)) }
-    return WebuiResponseData {
-        string: str
-        int: str.int()
-        bool: str == "true"
-    }
+
+pub fn (e &CEvent) get() WebuiResponseData {
+	str := unsafe { cstring_to_vstring(C.webui_get_string(e)) }
+	return WebuiResponseData{
+		string: str
+		int: str.int()
+		bool: str == 'true'
+	}
 }
 
 // Return
-type Response = int | string | bool
-pub fn (e &CEvent) @return (response Response) {
-    match response {
-        string {
-            C.webui_return_string(e, &char(response.str))
-    	} int {
-            C.webui_return_int(e, i64(response))
-    	} bool {
-            C.webui_return_bool(e, int(response))
-    	}
-    }
+type Response = bool | int | string
+
+pub fn (e &CEvent) @return(response Response) {
+	match response {
+		string {
+			C.webui_return_string(e, &char(response.str))
+		}
+		int {
+			C.webui_return_int(e, i64(response))
+		}
+		bool {
+			C.webui_return_bool(e, int(response))
+		}
+	}
 }
 
 // Create a new webui window object.
@@ -164,48 +172,47 @@ pub fn wait() {
 }
 
 // Show a window using a embedded HTML, or a file. If the window is already opened then it will be refreshed.
-pub fn (window Window) show (content string) bool {
+pub fn (window Window) show(content string) bool {
 	return C.webui_show(window, content.str)
 }
 
 // Show a window using a embedded HTML, or a file with specific browser. If the window is already opened then it will be refreshed.
-pub fn (window Window) show_browser (content string, browser_id browser) bool {
+pub fn (window Window) show_browser(content string, browser_id browser) bool {
 	return C.webui_show_browser(window, content.str, browser_id)
 }
 
 // Check a specific window if it's still running
-pub fn (window Window) is_shown () bool {
+pub fn (window Window) is_shown() bool {
 	return C.webui_is_shown(window)
 }
 
 // Allow the window URL to be re-used in normal web browsers
-pub fn (window Window) set_multi_access (status bool) Window {
+pub fn (window Window) set_multi_access(status bool) Window {
 	C.webui_set_multi_access(window, status)
 	return window
 }
 
 // Run JavaScript quickly with no waiting for the response.
-pub fn (window Window) run (script string) Window {
+pub fn (window Window) run(script string) Window {
 	C.webui_run(window, &char(script.str))
 	return window
 }
 
 // Chose between Deno and Nodejs runtime for .js and .ts files.
-pub fn (window Window) set_runtime (runtime runtime) Window {
+pub fn (window Window) set_runtime(runtime runtime) Window {
 	C.webui_set_runtime(window, runtime)
 	return window
 }
 
 // Close a specific window only.
-pub fn (window Window) close () {
+pub fn (window Window) close() {
 	C.webui_close(window)
 }
 
 // Close a specific window and clear all resources.
-pub fn (window Window) destroy () {
+pub fn (window Window) destroy() {
 	C.webui_destroy(window)
 }
-
 
 // Close all opened windows. webui_wait() will break.
 pub fn exit() {
@@ -213,7 +220,7 @@ pub fn exit() {
 }
 
 // Set the window in Kiosk mode (Full screen)
-pub fn (window Window) set_kiosk (kiosk bool) Window {
+pub fn (window Window) set_kiosk(kiosk bool) Window {
 	C.webui_set_kiosk(window, kiosk)
 	return window
 }
@@ -224,8 +231,8 @@ fn native_event_handler(e &CEvent) {
 		win_id := C.webui_interface_get_window_id(e.window)
 		func := function_list[win_id][bind_id]
 		resp := func(Event{
-			window: e.window,
-			event_type: vwebui.event(e.event_type)
+			window: e.window
+			event_type: event(e.event_type)
 			element: e.element.vstring()
 			data: e.get()
 			event_number: e.event_number
@@ -236,17 +243,17 @@ fn native_event_handler(e &CEvent) {
 
 fn native_raw_event_handler(e &CEvent) {
 	native_event_handler(&CEvent{
-		window: e.window,
-		event_type: e.event_type,
-		element: c"",
-		data: e.data,
+		window: e.window
+		event_type: e.event_type
+		element: c''
+		data: e.data
 		event_number: e.event_number
 	})
 }
 
 // Bind a specific html element click event with a function. Empty element means all events.
-pub fn (window Window) bind (element string, func Function) Window {
-	bind_id := if element != "" {
+pub fn (window Window) bind(element string, func Function) Window {
+	bind_id := if element != '' {
 		C.webui_bind(window, &char(element.str), native_event_handler)
 	} else {
 		C.webui_bind(window, &char(element.str), native_raw_event_handler)
@@ -256,7 +263,7 @@ pub fn (window Window) bind (element string, func Function) Window {
 }
 
 // Set the maximum time in seconds to wait for browser to start
-pub fn set_timeout(timeout u64){
+pub fn set_timeout(timeout u64) {
 	C.webui_set_timeout(timeout)
 }
 


### PR DESCRIPTION
I was so sassy to format the files, as the formatting was a bit mixed up and it gave me easier time to read them. Also I found that having `[translated]` followed by a comment stops formatting of the whole file with v fmt. So I moved it below the meta data comment in `vwebui.v`. I try to submit a fix for this v fmt Bug upstream next week or so but I think it's also good having `[translated]` below the comment.