### PR TITLE
Update C functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 *.def
 *.obj
 webui/
+setup
 
 # IDE
 .idea/

--- a/src/lib.c.v
+++ b/src/lib.c.v
@@ -17,7 +17,7 @@ fn C.webui_new_window_id(win_id Window)
 fn C.webui_get_new_window_id() Window
 fn C.webui_bind(win Window, elem &char, func fn (&CEvent)) Window
 fn C.webui_show(win Window, content &char) bool
-fn C.webui_show_browser(win Window, content &char, browser browser) bool
+fn C.webui_show_browser(win Window, content &char, browser Browser) bool
 fn C.webui_set_kiosk(win Window, kiosk bool)
 fn C.webui_wait()
 fn C.webui_close(win Window)
@@ -35,7 +35,7 @@ fn C.webui_set_multi_access(win Window, status bool)
 // -- JavaScript ----------------------
 fn C.webui_run(win Window, script &char)
 fn C.webui_script(win Window, script &char, timeout u64, buffer &char, buffer_length u64) bool
-fn C.webui_set_runtime(win Window, runtime runtime)
+fn C.webui_set_runtime(win Window, runtime Runtime)
 fn C.webui_get_int(e &CEvent) i64
 fn C.webui_get_string(e &CEvent) &char
 fn C.webui_get_bool(e &CEvent) bool

--- a/src/lib.c.v
+++ b/src/lib.c.v
@@ -1,0 +1,58 @@
+module vwebui
+
+#include "@VMODROOT/webui/webui.h"
+
+#flag -L@VMODROOT/webui -lwebui-2-static-x64 -lpthread -lm
+#flag windows @VMODROOT/webui/webui-2-x64.dll -lws2_32
+#flag -DNDEBUG -DNO_CACHING -DNO_CGI -DNO_SSL -DUSE_WEBSOCKET -DMUST_IMPLEMENT_CLOCK_GETTIME
+
+// Debug
+$if webui_log ? {
+	#flag -DWEBUI_LOG
+}
+
+// -- Definitions ---------------------
+fn C.webui_new_window() Window
+fn C.webui_new_window_id(win_id Window)
+fn C.webui_get_new_window_id() Window
+fn C.webui_bind(win Window, elem &char, func fn (&CEvent)) Window
+fn C.webui_show(win Window, content &char) bool
+fn C.webui_show_browser(win Window, content &char, browser browser) bool
+fn C.webui_set_kiosk(win Window, kiosk bool)
+fn C.webui_wait()
+fn C.webui_close(win Window)
+fn C.webui_destroy(win Window)
+fn C.webui_exit()
+fn C.webui_set_root_folder(win Window, path &char) // currently unused
+fn C.webui_set_file_handler(win Window, handler fn (file_name &char, length int)) // currently unused
+
+// -- Definitions ---------------------
+fn C.webui_is_shown(win Window) bool
+fn C.webui_set_timeout(second u64)
+fn C.webui_set_icon(win Window, icon &char, icon_type &char)
+fn C.webui_set_multi_access(win Window, status bool)
+
+// -- JavaScript ----------------------
+fn C.webui_run(win Window, script &char)
+fn C.webui_script(win Window, script &char, timeout u64, buffer &char, buffer_length u64) bool
+fn C.webui_set_runtime(win Window, runtime runtime)
+fn C.webui_get_int(e &CEvent) i64
+fn C.webui_get_string(e &CEvent) &char
+fn C.webui_get_bool(e &CEvent) bool
+fn C.webui_return_int(e &CEvent, n i64)
+fn C.webui_return_string(e &CEvent, s &char)
+fn C.webui_return_bool(e &CEvent, b bool)
+
+fn C.webui_encode(str &char) &char // currently unused
+fn C.webui_decode(str &char) &char // currently unused
+fn C.webui_free(ptr voidptr) // currently unused
+fn C.webui_malloc(size u64) voidptr // currently unused
+fn C.webui_send_raw(size Window, func &char, raw voidptr, size u64) // currently unused
+fn C.webui_set_hide(win Window, status bool) // currently unused
+
+// -- Interface -----------------------
+fn C.webui_interface_bind(win Window, element &char, func fn (win Window, event_type EventType, element &char, data &char, data_size u64, event_num u64)) u64 // currently unused
+fn C.webui_interface_set_response(win Window, event_num u64, resp &char) // currently unused
+fn C.webui_interface_is_app_running() bool
+fn C.webui_interface_get_window_id(win Window) Window
+fn C.webui_interface_get_bind_id(win Window, element &char) Window

--- a/src/lib.v
+++ b/src/lib.v
@@ -1,6 +1,6 @@
 /*
 V-WebUI 2.3.0
-https://github.com/malisipi/vwebui
+https://github.com/webui-dev/v-webui
 Copyright (c) 2023 Mehmet Ali.
 Licensed under MIT License.
 All rights reserved.
@@ -9,20 +9,6 @@ All rights reserved.
 [translated]
 module vwebui
 
-// WebUI Core
-
-#include "@VMODROOT/webui/webui.h"
-
-#flag -L@VMODROOT/webui -lwebui-2-static-x64 -lpthread -lm
-#flag windows @VMODROOT/webui/webui-2-x64.dll -lws2_32
-#flag -DNDEBUG -DNO_CACHING -DNO_CGI -DNO_SSL -DUSE_WEBSOCKET -DMUST_IMPLEMENT_CLOCK_GETTIME
-
-// Debug
-$if webui_log ? {
-	#flag -DWEBUI_LOG
-}
-
-// Consts
 __global (
 	function_list map[u64]map[u64]Function
 )
@@ -83,55 +69,6 @@ pub mut:
 }
 
 pub type Function = fn (e &Event) Response
-
-// C Functions
-
-// -- Definitions ---------------------
-fn C.webui_new_window() Window
-fn C.webui_new_window_id(win_id Window)
-fn C.webui_get_new_window_id() Window
-fn C.webui_bind(win Window, elem &char, func fn (&CEvent)) Window
-fn C.webui_show(win Window, content &char) bool
-fn C.webui_show_browser(win Window, content &char, browser browser) bool
-fn C.webui_set_kiosk(win Window, kiosk bool)
-fn C.webui_wait()
-fn C.webui_close(win Window)
-fn C.webui_destroy(win Window)
-fn C.webui_exit()
-fn C.webui_set_root_folder(win Window, path &char) // currently unused
-fn C.webui_set_file_handler(win Window, handler fn (file_name &char, length int)) // currently unused
-
-// -- Definitions ---------------------
-fn C.webui_is_shown(win Window) bool
-fn C.webui_set_timeout(second u64)
-fn C.webui_set_icon(win Window, icon &char, icon_type &char)
-fn C.webui_set_multi_access(win Window, status bool)
-
-// -- JavaScript ----------------------
-fn C.webui_run(win Window, script &char)
-fn C.webui_script(win Window, script &char, timeout u64, buffer &char, buffer_length u64) bool
-fn C.webui_set_runtime(win Window, runtime runtime)
-fn C.webui_get_int(e &CEvent) i64
-fn C.webui_get_string(e &CEvent) &char
-fn C.webui_get_bool(e &CEvent) bool
-fn C.webui_return_int(e &CEvent, n i64)
-fn C.webui_return_string(e &CEvent, s &char)
-fn C.webui_return_bool(e &CEvent, b bool)
-fn C.webui_encode(str &char) &char // currently unused
-fn C.webui_decode(str &char) &char // currently unused
-fn C.webui_free(ptr voidptr) // currently unused
-fn C.webui_malloc(size u64) voidptr // currently unused
-fn C.webui_send_raw(size Window, func &char, raw voidptr, size u64) // currently unused
-fn C.webui_set_hide(win Window, status bool) // currently unused
-
-// -- Interface -----------------------
-fn C.webui_interface_bind(win Window, element &char, func fn (win u64, event_type u64, element &char, data &char, data_size u64, event_num 64)) u64 // currently unused
-fn C.webui_interface_set_response(win Window, event_num u64, resp &char) // currently unused
-fn C.webui_interface_is_app_running() bool
-fn C.webui_interface_get_window_id(win Window) Window
-fn C.webui_interface_get_bind_id(win Window, element &char) Window
-
-// V Interface
 
 pub fn (window Window) script(javascript string, timeout u64, size_buffer int) string {
 	response := &char(' '.repeat(size_buffer).str)

--- a/src/lib.v
+++ b/src/lib.v
@@ -13,7 +13,7 @@ __global (
 	function_list map[u64]map[u64]Function
 )
 
-pub enum event as u64 {
+pub enum EventType {
 	disconnected = 0
 	connected = 1
 	multi_connection = 2
@@ -23,7 +23,7 @@ pub enum event as u64 {
 	callback = 6
 }
 
-pub enum browser as u64 {
+pub enum Browser {
 	any = 0
 	chrome = 1
 	firefox = 2
@@ -37,7 +37,7 @@ pub enum browser as u64 {
 	yandex = 10
 }
 
-pub enum runtime as u64 {
+pub enum Runtime {
 	@none = 0
 	deno = 1
 	nodejs = 2
@@ -61,9 +61,9 @@ pub type CFunction = fn (e &CEvent)
 
 pub struct Event {
 pub mut:
-	window       Window // Pointer to the window object
-	event_type   event  // Event type
-	element      string // HTML element ID
+	window       Window    // Pointer to the window object
+	event_type   EventType // Event type
+	element      string    // HTML element ID
 	data         WebuiResponseData // JavaScript data
 	event_number u64 // To set the callback response
 }
@@ -126,7 +126,7 @@ pub fn (window Window) show(content string) bool {
 }
 
 // Show a window using a embedded HTML, or a file with specific browser. If the window is already opened then it will be refreshed.
-pub fn (window Window) show_browser(content string, browser_id browser) bool {
+pub fn (window Window) show_browser(content string, browser_id Browser) bool {
 	return C.webui_show_browser(window, &char(content.str), browser_id)
 }
 
@@ -146,7 +146,7 @@ pub fn (window Window) run(script string) {
 }
 
 // Chose between Deno and Nodejs runtime for .js and .ts files.
-pub fn (window Window) set_runtime(runtime runtime) {
+pub fn (window Window) set_runtime(runtime Runtime) {
 	C.webui_set_runtime(window, runtime)
 }
 
@@ -177,7 +177,7 @@ fn native_event_handler(e &CEvent) {
 		func := function_list[win_id][bind_id]
 		resp := func(Event{
 			window: e.window
-			event_type: event(e.event_type)
+			event_type: EventType(e.event_type)
 			element: e.element.vstring()
 			data: e.get()
 			event_number: e.event_number

--- a/vwebui.v
+++ b/vwebui.v
@@ -52,9 +52,12 @@ pub enum browser as u64 {
 }
 
 pub enum runtime as u64 {
-	runtime_none = 0
-	runtime_deno = 1
-	runtime_nodejs = 2
+	runtime_none = 0 [deprecated: 'use none instead']
+	runtime_deno = 1 [deprecated: 'use deno instead']
+	runtime_nodejs = 2 [deprecated: 'use nodejs instead']
+	@none = 0
+	deno = 1
+	nodejs = 2
 }
 
 // Typedefs of struct

--- a/vwebui.v
+++ b/vwebui.v
@@ -182,21 +182,18 @@ pub fn (window Window) is_shown() bool {
 }
 
 // Allow the window URL to be re-used in normal web browsers
-pub fn (window Window) set_multi_access(status bool) Window {
+pub fn (window Window) set_multi_access(status bool) {
 	C.webui_set_multi_access(window, status)
-	return window
 }
 
 // Run JavaScript quickly with no waiting for the response.
-pub fn (window Window) run(script string) Window {
+pub fn (window Window) run(script string) {
 	C.webui_run(window, &char(script.str))
-	return window
 }
 
 // Chose between Deno and Nodejs runtime for .js and .ts files.
-pub fn (window Window) set_runtime(runtime runtime) Window {
+pub fn (window Window) set_runtime(runtime runtime) {
 	C.webui_set_runtime(window, runtime)
-	return window
 }
 
 // Close a specific window only.
@@ -215,9 +212,8 @@ pub fn exit() {
 }
 
 // Set the window in Kiosk mode (Full screen)
-pub fn (window Window) set_kiosk(kiosk bool) Window {
+pub fn (window Window) set_kiosk(kiosk bool) {
 	C.webui_set_kiosk(window, kiosk)
-	return window
 }
 
 fn native_event_handler(e &CEvent) {

--- a/vwebui.v
+++ b/vwebui.v
@@ -267,6 +267,11 @@ pub fn new_window_by_id(win_id u64) Window {
 	return get_window(win_id)
 }
 
+[deprecated: 'use get_new_window_id instead']
 pub fn new_id() u64 {
+	return C.webui_get_new_window_id()
+}
+
+pub fn get_new_window_id() Window {
 	return C.webui_get_new_window_id()
 }

--- a/vwebui.v
+++ b/vwebui.v
@@ -86,22 +86,30 @@ pub type Function = fn (e &Event) Response
 
 // C Functions
 
+// -- Definitions ---------------------
 fn C.webui_new_window() Window
 fn C.webui_new_window_id(win_id Window)
-fn C.webui_bind(win Window, element &char, func fn (&CEvent)) Window
+fn C.webui_get_new_window_id() Window
+fn C.webui_bind(win Window, elem &char, func fn (&CEvent)) Window
 fn C.webui_show(win Window, content &char) bool
-fn C.webui_show_browser(win Window, content &char, browser u64) bool
+fn C.webui_show_browser(win Window, content &char, browser browser) bool
+fn C.webui_set_kiosk(win Window, kiosk bool)
 fn C.webui_wait()
 fn C.webui_close(win Window)
 fn C.webui_destroy(win Window)
 fn C.webui_exit()
+fn C.webui_set_root_folder(win Window, path &char) // currently unused
+fn C.webui_set_file_handler(win Window, handler fn (file_name &char, length int)) // currently unused
+
+// -- Definitions ---------------------
 fn C.webui_is_shown(win Window) bool
 fn C.webui_set_timeout(second u64)
 fn C.webui_set_icon(win Window, icon &char, icon_type &char)
 fn C.webui_set_multi_access(win Window, status bool)
+
+// -- JavaScript ----------------------
 fn C.webui_run(win Window, script &char)
-fn C.webui_script(win Window, script &char, timeout u64, buffer &char, size_buffer u64)
-fn C.webui_set_kiosk(win Window, kiosk bool)
+fn C.webui_script(win Window, script &char, timeout u64, buffer &char, buffer_length u64) bool
 fn C.webui_set_runtime(win Window, runtime runtime)
 fn C.webui_get_int(e &CEvent) i64
 fn C.webui_get_string(e &CEvent) &char
@@ -109,10 +117,19 @@ fn C.webui_get_bool(e &CEvent) bool
 fn C.webui_return_int(e &CEvent, n i64)
 fn C.webui_return_string(e &CEvent, s &char)
 fn C.webui_return_bool(e &CEvent, b bool)
+fn C.webui_encode(str &char) &char // currently unused
+fn C.webui_decode(str &char) &char // currently unused
+fn C.webui_free(ptr voidptr) // currently unused
+fn C.webui_malloc(size u64) voidptr // currently unused
+fn C.webui_send_raw(size Window, func &char, raw voidptr, size u64) // currently unused
+fn C.webui_set_hide(win Window, status bool) // currently unused
+
+// -- Interface -----------------------
+fn C.webui_interface_bind(win Window, element &char, func fn (win u64, event_type u64, element &char, data &char, data_size u64, event_num 64)) u64 // currently unused
+fn C.webui_interface_set_response(win Window, event_num u64, resp &char) // currently unused
 fn C.webui_interface_is_app_running() bool
 fn C.webui_interface_get_window_id(win Window) Window
 fn C.webui_interface_get_bind_id(win Window, element &char) Window
-fn C.webui_get_new_window_id() Window
 
 // V Interface
 

--- a/vwebui.v
+++ b/vwebui.v
@@ -52,9 +52,6 @@ pub enum browser as u64 {
 }
 
 pub enum runtime as u64 {
-	runtime_none = 0 [deprecated: 'use none instead']
-	runtime_deno = 1 [deprecated: 'use deno instead']
-	runtime_nodejs = 2 [deprecated: 'use nodejs instead']
 	@none = 0
 	deno = 1
 	nodejs = 2
@@ -268,11 +265,6 @@ pub fn get_window(win_id u64) Window {
 pub fn new_window_by_id(win_id u64) Window {
 	C.webui_new_window_id(win_id)
 	return get_window(win_id)
-}
-
-[deprecated: 'use get_new_window_id instead']
-pub fn new_id() u64 {
-	return C.webui_get_new_window_id()
 }
 
 pub fn get_new_window_id() Window {

--- a/vwebui.v
+++ b/vwebui.v
@@ -87,8 +87,8 @@ pub type Function = fn (e &Event) Response
 // C Functions
 
 fn C.webui_new_window() Window
-fn C.webui_new_window_id(win_id u64)
-fn C.webui_bind(win Window, element &char, func fn (&CEvent)) u64
+fn C.webui_new_window_id(win_id Window)
+fn C.webui_bind(win Window, element &char, func fn (&CEvent)) Window
 fn C.webui_show(win Window, content &char) bool
 fn C.webui_show_browser(win Window, content &char, browser u64) bool
 fn C.webui_wait()
@@ -102,7 +102,7 @@ fn C.webui_set_multi_access(win Window, status bool)
 fn C.webui_run(win Window, script &char)
 fn C.webui_script(win Window, script &char, timeout u64, buffer &char, size_buffer u64)
 fn C.webui_set_kiosk(win Window, kiosk bool)
-fn C.webui_set_runtime(win Window, runtime u64)
+fn C.webui_set_runtime(win Window, runtime runtime)
 fn C.webui_get_int(e &CEvent) i64
 fn C.webui_get_string(e &CEvent) &char
 fn C.webui_get_bool(e &CEvent) bool
@@ -110,9 +110,9 @@ fn C.webui_return_int(e &CEvent, n i64)
 fn C.webui_return_string(e &CEvent, s &char)
 fn C.webui_return_bool(e &CEvent, b bool)
 fn C.webui_interface_is_app_running() bool
-fn C.webui_interface_get_window_id(win Window) u64
-fn C.webui_interface_get_bind_id(win Window, element &char) u64
-fn C.webui_get_new_window_id() u64
+fn C.webui_interface_get_window_id(win Window) Window
+fn C.webui_interface_get_bind_id(win Window, element &char) Window
+fn C.webui_get_new_window_id() Window
 
 // V Interface
 


### PR DESCRIPTION
Changes in this PR:

- makes usage of type/enum declarations like `Window` and `runtime` unifrom
- matches function return values with underlying C functions
- superseeds `new_id` with `get_new_window_id` to uniformly use function names based on the C webui functions - e.g. `webui_get_new_window_id`
- updates runtime enum values to allow `.nodejs` instead of `.runtime_nodejs` as runtime arg.
  This matches usage in C and go `NodeJS`, as well as other enums in V like `browser`, where one can pass e.g. `.chromium` instead of `.browser_chromium`

I'd suggest that deprecated code is removed with 2.4

