### PR TITLE
Add build workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,92 @@
+name: CI
+
+on:
+  push:
+    paths-ignore: ['**/*.md']
+  pull_request:
+    paths-ignore: ['**/*.md']
+
+env:
+  # The path where the module would be installed with `v install <giturl>`
+  MOD_PATH: ~/.vmodules/vwebui
+
+defaults:
+  run:
+    # necessary for windows
+    shell: bash
+
+jobs:
+  setup:
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Cache Status
+        id: cache-status
+        uses: actions/cache@v3
+        with:
+          path: vlang
+          key: ${{ runner.os }}-v-
+
+      - if: ${{ steps.cache-status.outputs.cache-hit != 'true' }}
+        name: Install V
+        uses: vlang/setup-v@v1.3
+        with:
+          check-latest: true
+
+      - if: ${{ steps.cache-status.outputs.cache-hit != 'true' }}
+        name: Add V Version to Environment
+        run: echo "V_VER=$(v -v)" >> $GITHUB_ENV
+
+      - if: ${{ steps.cache-status.outputs.cache-hit != 'true' }}
+        name: Cache V
+        uses: actions/cache/save@v3
+        with:
+          path: vlang
+          key: ${{ runner.os }}-v-${{ env.V_VER }}
+
+  build:
+    needs: setup
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-latest, windows-latest]
+        compiler: [tcc, gcc, clang]
+        optimization: ['', -cstrict, -prod]
+        # excluding arrays / multiple values at once apparently doesn't work properly
+        exclude:
+          - os: macos-latest
+            optimization: -cstrict
+          - os: windows-latest
+            optimization: -cstrict
+          - compiler: tcc
+            optimization: -prod
+          # only gcc on windows for now
+          - os: windows-latest
+            compiler: tcc
+          - os: windows-latest
+            compiler: clang
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Restore V Cache
+        uses: actions/cache/restore@v3
+        with:
+          path: vlang
+          key: ${{ runner.os }}-v-
+          fail-on-cache-miss: true
+
+      - name: Setup V
+        uses: vlang/setup-v@v1.3
+
+      - name: Checkout ${{ github.event.repository.name }}
+        uses: actions/checkout@v3
+        with:
+          path: ${{ github.event.repository.name }}
+
+      - name: Copy ${{ github.event.repository.name }} to .vmodules
+        run: cp -r ${{ github.event.repository.name }} ${{ env.MOD_PATH }}
+
+      - name: Build
+        run: |
+          v -cg -cc ${{ matrix.compiler }} ${{ matrix.optimization }} ${{ env.MOD_PATH }}/examples/minimal.v


### PR DESCRIPTION
This PR adds a comprehensive yet simple build workflow to assure builds work on linux, windows and macos. It also runs the builds with several optimizations like `-prod`.

Additional info for macOS M1:
GitHub plans Apple Silicon runners for public testing in Q3 of 2023. Until then we only have x64 runners for macos.

For Windows:
As far as I could test with the ci and on my local system, Windows will require compilation with `gcc` when using the planned static gcc pre-builts. Therefore the ci builts Windows only with `gcc` - others would fail. Including a pre-built static clang versions in future releases might be worth considering to solve this. 

The CI will become green with #27
- Example run: 
  https://github.com/tobealive/v-webui/actions/runs/5506931824
- Prior to it we would have some failing builds with `-cstrict`:
  https://github.com/tobealive/v-webui/actions/runs/5506913677