### PR TITLE
Reimplement event handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,21 +48,21 @@ const html = '<!DOCTYPE html>
   <head>
     <style>
       body {
-        background-color: SlateGray;
-        color: GhostWhite;
+        background: linear-gradient(to left, #36265a, #654da9);
+        color: AliceBlue;
+        font: 16px sans-serif;
         text-align: center;
       }
     </style>
   </head>
   <body>
-    <button onclick="webui.call(\'my_v_func\')">Call V!</button>
     <h1>Thanks for using WebUI!</h1>
+    <button onclick="webui.call(\'my_v_func\')">Call V!</button>
   </body>
 </html>'
 
-fn my_v_func(e &ui.Event) ui.Response {
+fn my_v_func(e &ui.Event) {
 	println('Hello From V!')
-	return 0
 }
 
 w := ui.new_window()

--- a/examples/call_js_from_v.v
+++ b/examples/call_js_from_v.v
@@ -1,52 +1,51 @@
 import vwebui as ui
 
-fn my_function_count(e &ui.Event) ui.Response {
+fn my_function_count(e &ui.Event) {
 	count := e.window.script('return count;', 0, 48)
 	e.window.script('SetCount(${count.int() + 1});', 0, 0)
-	return 0
 }
 
-fn my_function_exit(e &ui.Event) ui.Response { // Close all opened windows
+// Close all opened windows
+fn my_function_exit(e &ui.Event) {
 	ui.exit()
-	return 0
 }
 
 // UI HTML
 const doc = '<!DOCTYPE html>
 <html>
-  <head>
-    <title>Call JavaScript from V Example</title>
-    <style>
-      body {
-        background: linear-gradient(to left, #36265a, #654da9);
-        color: AliceBlue;
-        font: 16px sans-serif;
-        text-align: center;
-        margin-top: 30px;
-      }
-      button {
-        margin: 5px 0 10px;
-      }
-    </style>
-  </head>
-  <body>
-    <h1>WebUI - Call JavaScript from V</h1>
-    <br>
-    <button id="MyButton1">Count <span id="count">0<span></button>
-    <br>
-    <br>
-    <button id="MyButton2">Exit</button>
-    <script>
-      let count = document.getElementById("count").innerHTML;
-      function SetCount(number) {
-        document.getElementById("count").innerHTML = number;
-        count = number;
-      }
-    </script>
-  </body>
+	<head>
+	<title>Call JavaScript from V Example</title>
+	<style>
+	body {
+		background: linear-gradient(to left, #36265a, #654da9);
+		color: AliceBlue;
+		font: 16px sans-serif;
+		text-align: center;
+		margin-top: 30px;
+	}
+	button {
+		margin: 5px 0 10px;
+	}
+	</style>
+	</head>
+	<body>
+		<h1>WebUI - Call JavaScript from V</h1>
+		<br>
+		<button id="MyButton1">Count <span id="count">0<span></button>
+		<br>
+		<button id="MyButton2">Exit</button>
+		<script>
+			let count = document.getElementById("count").innerHTML;
+			function SetCount(number) {
+				document.getElementById("count").innerHTML = number;
+				count = number;
+			}
+		</script>
+	</body>
 </html>'
 
-mut w := ui.new_window() // Create a window
+// Create a window
+mut w := ui.new_window()
 
 // Bind HTML elements with functions
 w.bind('MyButton1', my_function_count)

--- a/examples/call_v_from_js.v
+++ b/examples/call_v_from_js.v
@@ -1,44 +1,41 @@
 import vwebui as ui
 
-fn my_function_string(e &ui.Event) ui.Response {
+fn my_function_string(e &ui.Event) {
 	// JavaScript:
 	// webui.call('MyID_One', 'Hello');
 
-	response := e.data.string
+	response := e.string()
 	println('my_function_string: ${response}') // Hello
 
 	// Need Multiple Arguments?
 	//
 	// WebUI support only one argument. To get multiple arguments
 	// you can send a JSON string from JavaScript then decode it.
-	return 0
 }
 
-fn my_function_integer(e &ui.Event) ui.Response {
+fn my_function_integer(e &ui.Event) {
 	// JavaScript:
 	// webui.call('MyID_Two', 123456789);
 
-	response := e.data.int
+	response := e.int()
 	println('my_function_integer: ${response}') // 123456789
-	return 0
 }
 
-fn my_function_boolean(e &ui.Event) ui.Response {
+fn my_function_boolean(e &ui.Event) {
 	// JavaScript:
 	// webui.call('MyID_Three', true);
 
-	response := e.data.bool
+	response := e.bool()
 	println('my_function_boolean: ${response}') // true
-	return 0
 }
 
-fn my_function_with_response(e &ui.Event) ui.Response {
+fn my_function_with_response(e &ui.Event) {
 	// JavaScript:
 	// const result = webui.call('MyID_Four', number);
 
-	number := e.data.int * 2
+	number := e.int() * 2
 	println('my_function_with_response: ${number}')
-	return number
+	e.@return(number)
 }
 
 const doc = '<!DOCTYPE html>
@@ -90,9 +87,9 @@ if !w.show(doc) { // Run the window
 }
 
 w.bind('MyID_One', my_function_string)
-	.bind('MyID_Two', my_function_integer)
-	.bind('MyID_Three', my_function_boolean)
-	.bind('MyID_Four', my_function_with_response)
+w.bind('MyID_Two', my_function_integer)
+w.bind('MyID_Three', my_function_boolean)
+w.bind('MyID_Four', my_function_with_response)
 
 // Wait until all windows get closed
 ui.wait()

--- a/examples/serve_a_folder/main.v
+++ b/examples/serve_a_folder/main.v
@@ -33,7 +33,6 @@ fn exit_app(e &ui.Event) {
 
 fn main() {
 	w.new_window()
-	w.set_root_folder(@VMODROOT)
 
 	w.bind('SwitchToSecondPage', switch_to_second_page)
 	w.bind('OpenNewWindow', show_second_window)
@@ -42,8 +41,8 @@ fn main() {
 	w.show('index.html') // Show a new window
 
 	w2.new_window()
-	w2.set_root_folder(@VMODROOT)
 	w2.bind('Exit', exit_app)
 
+	ui.set_root_folder(@VMODROOT)
 	ui.wait() // Wait until all windows get closed
 }

--- a/examples/serve_a_folder/main.v
+++ b/examples/serve_a_folder/main.v
@@ -1,13 +1,12 @@
 import vwebui as ui
 
 const (
-	my_window        = 1
-	my_second_window = 2
+	w  = ui.Window(1)
+	w2 = ui.Window(2)
 )
 
-fn events(e &ui.Event) ui.Response { // Close all opened windows
-	// This function gets called every time
-	// there is an event
+// This function gets called every time there is an event
+fn events(e &ui.Event) {
 	if e.event_type == .connected {
 		println('Connected.')
 	} else if e.event_type == .disconnected {
@@ -15,40 +14,34 @@ fn events(e &ui.Event) ui.Response { // Close all opened windows
 	} else if e.event_type == .mouse_click {
 		println('Click.')
 	} else if e.event_type == .navigation {
-		println('Starting navigation to: ${e.data}')
+		println('Starting navigation to: ${e.string()}')
 	}
-	return 0
 }
 
-fn switch_to_second_page(e &ui.Event) ui.Response {
-	// This function gets called every
-	// time the user clicks on "SwitchToSecondPage"
-	// Switch to `/second.html` in the same opened window.
+// Switch to `/second.html` in the same opened window.
+fn switch_to_second_page(e &ui.Event) {
 	e.window.show('second.html')
-	return 0
 }
 
-fn show_second_window(e &ui.Event) ui.Response {
-	ui.get_window(my_second_window).show('second.html')
-	return 0
+fn show_second_window(e &ui.Event) {
+	w2.show('second.html')
 }
 
-fn exit_app(e &ui.Event) ui.Response { // Close all opened windows
+fn exit_app(e &ui.Event) {
 	ui.exit()
-	return 0
 }
 
 fn main() {
-	w := ui.new_window_by_id(my_window)
+	w.new_window()
 	w.set_root_folder(@VMODROOT)
 
 	w.bind('SwitchToSecondPage', switch_to_second_page)
-		.bind('OpenNewWindow', show_second_window)
-		.bind('Exit', exit_app)
-		.bind('', events) // Bind events
-		.show('index.html') // Show a new window
+	w.bind('OpenNewWindow', show_second_window)
+	w.bind('Exit', exit_app)
+	w.bind('', events) // Bind events
+	w.show('index.html') // Show a new window
 
-	w2 := ui.new_window_by_id(my_second_window)
+	w2.new_window()
 	w2.set_root_folder(@VMODROOT)
 	w2.bind('Exit', exit_app)
 

--- a/examples/simple_example.v
+++ b/examples/simple_example.v
@@ -1,23 +1,5 @@
 import vwebui as ui
 
-fn check_the_password(e &ui.Event) ui.Response { // Check the password function
-	password := e.window.script('return document.getElementById("MyInput").value;', 0,
-		4096)
-	println('Password: ' + password)
-
-	if password == '123456' { // Check the password
-		e.window.run("alert('Good. Password is correct.');") // Correct password
-	} else {
-		e.window.run("alert('Sorry. Wrong password.');") // Wrong password
-	}
-	return 0
-}
-
-fn close_the_application(e &ui.Event) ui.Response { // Close all opened windows
-	ui.exit()
-	return 0
-}
-
 // UI HTML
 const doc = '<!DOCTYPE html>
 <html>
@@ -43,15 +25,33 @@ const doc = '<!DOCTYPE html>
 	</body>
 </html>'
 
-mut w := ui.new_window() // Create a window
+fn check_the_password(e &ui.Event) {
+	password := e.window.script('return document.getElementById("MyInput").value;', 0,
+		4096)
+	println('Password: ' + password)
 
-// Bind HTML elements with functions
+	if password == '123456' {
+		e.window.run("alert('Good. Password is correct.');")
+	} else {
+		e.window.run("alert('Sorry. Wrong password.');")
+	}
+}
+
+// Close all opened windows
+fn close_the_application(e &ui.Event) {
+	ui.exit()
+}
+
+// Create a window
+mut w := ui.new_window()
+
+// Bind HTML elements to functions
 w.bind('MyButton1', check_the_password)
 w.bind('MyButton2', close_the_application)
 
-// Show the window
-if !w.show(doc) { // Run the window
-	panic('The browser(s) was failed') // If not, print a error info
+// Show the window, panic on fail
+if !w.show(doc) {
+	panic('Failed showing window.')
 }
 
 // Wait until all windows get closed

--- a/examples/text-editor/main.v
+++ b/examples/text-editor/main.v
@@ -3,19 +3,19 @@ import encoding.base64
 import os
 import json
 
-fn close(e &ui.Event) ui.Response {
+fn close(e &ui.Event) {
 	ui.exit()
-	return 0
 }
 
-fn open(e &ui.Event) ui.Response {
-	if e.data.string == '' {
+fn open(e &ui.Event) {
+	str := e.string()
+	if str == '' {
 		e.window.run("webui.call('Open', prompt`File Location`)")
-		return 0
-	} else if e.data.string == 'null' {
-		return 0
+		return
+	} else if str == 'null' {
+		return
 	}
-	file := e.data.string
+	file := e.string()
 	if file != '' {
 		file_content := os.read_file(file) or {
 			println('Failed to read file: ${file}')
@@ -28,7 +28,6 @@ fn open(e &ui.Event) ui.Response {
 		e.window.run('addText`${encoded_file_content}`')
 		e.window.run('window.opened_file = `${file}`')
 	}
-	return 0
 }
 
 struct Save {
@@ -36,13 +35,12 @@ struct Save {
 	content string
 }
 
-fn save(e &ui.Event) ui.Response {
-	resp := json.decode(Save, e.data.string) or {
-		e.window.run("ui.call('Save', JSON.stringify({file:window.opened_file,content:window.atob`${base64.encode_str(e.data.string)}`}))")
-		return 0
+fn save(e &ui.Event) {
+	resp := json.decode(Save, e.string()) or {
+		e.window.run("ui.call('Save', JSON.stringify({file:window.opened_file,content:window.atob`${base64.encode_str(e.string())}`}))")
+		return
 	}
 	os.write_file(resp.file, resp.content) or { panic(err) }
-	return 0
 }
 
 fn main() {
@@ -51,9 +49,9 @@ fn main() {
 	w.set_root_folder(@VMODROOT)
 
 	w.bind('Open', open)
-		.bind('Save', save)
-		.bind('Close', close)
-		.show('ui/MainWindow.html')
+	w.bind('Save', save)
+	w.bind('Close', close)
+	w.show('ui/MainWindow.html')
 
 	ui.wait()
 }

--- a/src/lib.c.v
+++ b/src/lib.c.v
@@ -30,7 +30,7 @@ fn C.webui_exit()
 fn C.webui_set_root_folder(win Window, path &char)
 fn C.webui_set_file_handler(win Window, handler fn (file_name &char, length int)) // currently unused
 
-// -- Definitions ---------------------
+// -- Other ---------------------------
 fn C.webui_is_shown(win Window) bool
 fn C.webui_set_timeout(second usize)
 fn C.webui_set_icon(win Window, icon &char, icon_type &char)
@@ -46,7 +46,6 @@ fn C.webui_get_bool(e &Event) bool
 fn C.webui_return_int(e &Event, n i64)
 fn C.webui_return_string(e &Event, s &char)
 fn C.webui_return_bool(e &Event, b bool)
-
 fn C.webui_encode(str &char) &char // currently unused
 fn C.webui_decode(str &char) &char // currently unused
 fn C.webui_free(ptr voidptr) // currently unused

--- a/src/lib.c.v
+++ b/src/lib.c.v
@@ -4,12 +4,6 @@ module vwebui
 
 #flag -L@VMODROOT/webui -lwebui-2-static-x64 -lpthread -lm
 #flag windows @VMODROOT/webui/webui-2-x64.dll -lws2_32
-#flag -DNDEBUG -DNO_CACHING -DNO_CGI -DNO_SSL -DUSE_WEBSOCKET -DMUST_IMPLEMENT_CLOCK_GETTIME
-
-// Debug
-$if webui_log ? {
-	#flag -DWEBUI_LOG
-}
 
 struct C.webui_event_t {
 pub:

--- a/src/lib.c.v
+++ b/src/lib.c.v
@@ -28,6 +28,7 @@ fn C.webui_close(win Window)
 fn C.webui_destroy(win Window)
 fn C.webui_exit()
 fn C.webui_set_root_folder(win Window, path &char)
+fn C.webui_set_default_root_folder(path &char)
 fn C.webui_set_file_handler(win Window, handler fn (file_name &char, length int)) // currently unused
 
 // -- Other ---------------------------

--- a/src/lib.c.v
+++ b/src/lib.c.v
@@ -11,11 +11,21 @@ $if webui_log ? {
 	#flag -DWEBUI_LOG
 }
 
+struct C.webui_event_t {
+pub:
+	window       Window    // The window object number
+	event_type   EventType // Event type
+	element      &char     // HTML element ID
+	data         &char     // JavaScript data
+	size         usize     // JavaScript data len
+	event_number usize     // Internal WebUI
+}
+
 // -- Definitions ---------------------
 fn C.webui_new_window() Window
 fn C.webui_new_window_id(win_id Window)
 fn C.webui_get_new_window_id() Window
-fn C.webui_bind(win Window, elem &char, func fn (&CEvent)) Window
+fn C.webui_bind(win Window, elem &char, func fn (&Event)) Window
 fn C.webui_show(win Window, content &char) bool
 fn C.webui_show_browser(win Window, content &char, browser Browser) bool
 fn C.webui_set_kiosk(win Window, kiosk bool)
@@ -28,31 +38,31 @@ fn C.webui_set_file_handler(win Window, handler fn (file_name &char, length int)
 
 // -- Definitions ---------------------
 fn C.webui_is_shown(win Window) bool
-fn C.webui_set_timeout(second u64)
+fn C.webui_set_timeout(second usize)
 fn C.webui_set_icon(win Window, icon &char, icon_type &char)
 fn C.webui_set_multi_access(win Window, status bool)
 
 // -- JavaScript ----------------------
 fn C.webui_run(win Window, script &char)
-fn C.webui_script(win Window, script &char, timeout u64, buffer &char, buffer_length u64) bool
+fn C.webui_script(win Window, script &char, timeout usize, buffer &char, buffer_length usize) bool
 fn C.webui_set_runtime(win Window, runtime Runtime)
-fn C.webui_get_int(e &CEvent) i64
-fn C.webui_get_string(e &CEvent) &char
-fn C.webui_get_bool(e &CEvent) bool
-fn C.webui_return_int(e &CEvent, n i64)
-fn C.webui_return_string(e &CEvent, s &char)
-fn C.webui_return_bool(e &CEvent, b bool)
+fn C.webui_get_int(e &Event) i64
+fn C.webui_get_string(e &Event) &char
+fn C.webui_get_bool(e &Event) bool
+fn C.webui_return_int(e &Event, n i64)
+fn C.webui_return_string(e &Event, s &char)
+fn C.webui_return_bool(e &Event, b bool)
 
 fn C.webui_encode(str &char) &char // currently unused
 fn C.webui_decode(str &char) &char // currently unused
 fn C.webui_free(ptr voidptr) // currently unused
-fn C.webui_malloc(size u64) voidptr // currently unused
-fn C.webui_send_raw(size Window, func &char, raw voidptr, size u64) // currently unused
+fn C.webui_malloc(size usize) voidptr // currently unused
+fn C.webui_send_raw(size Window, func &char, raw voidptr, size usize) // currently unused
 fn C.webui_set_hide(win Window, status bool) // currently unused
 
 // -- Interface -----------------------
-fn C.webui_interface_bind(win Window, element &char, func fn (win Window, event_type EventType, element &char, data &char, data_size u64, event_num u64)) u64 // currently unused
-fn C.webui_interface_set_response(win Window, event_num u64, resp &char) // currently unused
+fn C.webui_interface_bind(win Window, element &char, func fn (win Window, event_type EventType, element &char, data &char, data_size usize, event_num usize)) usize // currently unused
+fn C.webui_interface_set_response(win Window, event_num usize, resp &char) // currently unused
 fn C.webui_interface_is_app_running() bool
 fn C.webui_interface_get_window_id(win Window) Window
 fn C.webui_interface_get_bind_id(win Window, element &char) Window

--- a/src/lib.v
+++ b/src/lib.v
@@ -81,9 +81,14 @@ pub fn (w Window) set_kiosk(kiosk bool) {
 	C.webui_set_kiosk(w, kiosk)
 }
 
-// Set the web-server root folder path.
+// Set the web-server root folder path for a specific window.
 pub fn (w Window) set_root_folder(path string) {
 	C.webui_set_root_folder(w, &char(path.str))
+}
+
+// Set the web-server root folder path for all windows.
+pub fn set_root_folder(path string) {
+	C.webui_set_default_root_folder(&char(path.str))
 }
 
 // Wait until all opened windows get closed.

--- a/src/lib.v
+++ b/src/lib.v
@@ -8,6 +8,12 @@ All rights reserved.
 
 module vwebui
 
+pub type Window = usize
+
+pub type Function = usize
+
+pub type Event = C.webui_event_t
+
 pub enum EventType {
 	disconnected = 0
 	connected = 1
@@ -38,57 +44,46 @@ pub enum Runtime {
 	nodejs = 2
 }
 
-pub type Window = usize
-
-pub type Function = usize
-
-pub type Event = C.webui_event_t
-
-pub fn (e &Event) string() string {
-	// Ensure GCC and Clang compiles with `-cstrict` flag
-	return unsafe { (&char(C.webui_get_string(e))).vstring() }
-}
-
-pub fn (e &Event) int() int {
-	return int(C.webui_get_int(e))
-}
-
-pub fn (e &Event) i64() i64 {
-	return C.webui_get_int(e)
-}
-
-pub fn (e &Event) bool() bool {
-	return C.webui_get_bool(e)
-}
-
-pub fn (window Window) script(javascript string, timeout usize, size_buffer int) string {
-	response := &char(' '.repeat(size_buffer).str)
-	C.webui_script(window, &char(javascript.str), timeout, response, size_buffer)
-	return unsafe { response.vstring() }
-}
-
-type Response = bool | i64 | int | string
-
-pub fn (e &Event) @return(response Response) {
-	match response {
-		string {
-			C.webui_return_string(e, &char(response.str))
-		}
-		int {
-			C.webui_return_int(e, i64(response))
-		}
-		i64 {
-			C.webui_return_int(e, response)
-		}
-		bool {
-			C.webui_return_bool(e, response)
-		}
-	}
-}
+// == Definitions =============================================================
 
 // Create a new webui window object.
 pub fn new_window() Window {
 	return C.webui_new_window()
+}
+
+// Create a new webui window object.
+pub fn (w Window) new_window() {
+	C.webui_new_window_id(w)
+}
+
+// Get a free window ID that can be used with the `new_window` method.
+pub fn get_new_window_id() Window {
+	return C.webui_get_new_window_id()
+}
+
+// Bind a specific html element click event with a function. Empty element means all events.
+pub fn (w Window) bind(element string, func fn (&Event)) Function {
+	return C.webui_bind(w, &char(element.str), func)
+}
+
+// Show a window using embedded HTML, or a file. If the window is already open, it will be refreshed.
+pub fn (w Window) show(content string) bool {
+	return C.webui_show(w, &char(content.str))
+}
+
+// Show a window using embedded HTML, or a file in a specified browser. If the window is already open, it will be refreshed.
+pub fn (w Window) show_browser(content string, browser Browser) bool {
+	return C.webui_show_browser(w, &char(content.str), browser)
+}
+
+// Set the window in Kiosk mode (full screen).
+pub fn (w Window) set_kiosk(kiosk bool) {
+	C.webui_set_kiosk(w, kiosk)
+}
+
+// Set the web-server root folder path.
+pub fn (w Window) set_root_folder(path string) {
+	C.webui_set_root_folder(w, &char(path.str))
 }
 
 // Wait until all opened windows get closed.
@@ -96,74 +91,94 @@ pub fn wait() {
 	C.webui_wait()
 }
 
-// Show a window using a embedded HTML, or a file. If the window is already opened then it will be refreshed.
-pub fn (window Window) show(content string) bool {
-	return C.webui_show(window, &char(content.str))
+// Close the window. The window object will still exist.
+pub fn (w Window) close() {
+	C.webui_close(w)
 }
 
-// Show a window using a embedded HTML, or a file with specific browser. If the window is already opened then it will be refreshed.
-pub fn (window Window) show_browser(content string, browser_id Browser) bool {
-	return C.webui_show_browser(window, &char(content.str), browser_id)
+// Close the window and free all memory resources.
+pub fn (w Window) destroy() {
+	C.webui_destroy(w)
 }
 
-// Check a specific window if it's still running
-pub fn (window Window) is_shown() bool {
-	return C.webui_is_shown(window)
-}
-
-// Allow the window URL to be re-used in normal web browsers
-pub fn (window Window) set_multi_access(status bool) {
-	C.webui_set_multi_access(window, status)
-}
-
-// Run JavaScript quickly with no waiting for the response.
-pub fn (window Window) run(script string) {
-	C.webui_run(window, &char(script.str))
-}
-
-// Chose between Deno and Nodejs runtime for .js and .ts files.
-pub fn (window Window) set_runtime(runtime Runtime) {
-	C.webui_set_runtime(window, runtime)
-}
-
-// Close a specific window only.
-pub fn (window Window) close() {
-	C.webui_close(window)
-}
-
-// Close a specific window and clear all resources.
-pub fn (window Window) destroy() {
-	C.webui_destroy(window)
-}
-
-// Close all opened windows. webui_wait() will break.
+// Close all open windows. `wait()` will break.
 pub fn exit() {
 	C.webui_exit()
 }
 
-pub fn (window Window) set_root_folder(path string) {
-	C.webui_set_root_folder(window, &char(path.str))
+// == Other ===================================================================
+
+// Check if the window is still running.
+pub fn (w Window) is_shown() bool {
+	return C.webui_is_shown(w)
 }
 
-// Set the window in Kiosk mode (Full screen)
-pub fn (window Window) set_kiosk(kiosk bool) {
-	C.webui_set_kiosk(window, kiosk)
-}
-
-// Bind a specific html element click event with a function. Empty element means all events.
-pub fn (window Window) bind(element string, func fn (&Event)) Function {
-	return C.webui_bind(window, &char(element.str), func)
-}
-
-// Set the maximum time in seconds to wait for browser to start
+// Set the maximum time in seconds to wait for the browser to start.
 pub fn set_timeout(timeout usize) {
 	C.webui_set_timeout(timeout)
 }
 
-pub fn (win_id Window) new_window() {
-	C.webui_new_window_id(win_id)
+// Allow the window URL to be re-used in normal web browsers.
+pub fn (w Window) set_multi_access(status bool) {
+	C.webui_set_multi_access(w, status)
 }
 
-pub fn get_new_window_id() Window {
-	return C.webui_get_new_window_id()
+// == Javascript ==============================================================
+
+// Run JavaScript quickly with no waiting for the response.
+pub fn (w Window) run(script string) {
+	C.webui_run(w, &char(script.str))
+}
+
+// Run a JavaScript, and get the response back (Make sure your local buffer can hold the response).
+pub fn (w Window) script(javascript string, timeout usize, size_buffer int) string {
+	response := &char(' '.repeat(size_buffer).str)
+	C.webui_script(w, &char(javascript.str), timeout, response, size_buffer)
+	return unsafe { response.vstring() }
+}
+
+// Chose between Deno and Nodejs runtime for .js and .ts files.
+pub fn (w Window) set_runtime(runtime Runtime) {
+	C.webui_set_runtime(w, runtime)
+}
+
+// Parse argument as integer.
+pub fn (e &Event) int() int {
+	return int(C.webui_get_int(e))
+}
+
+// Parse argument as integer.
+pub fn (e &Event) i64() i64 {
+	return C.webui_get_int(e)
+}
+
+// Parse argument as string.
+pub fn (e &Event) string() string {
+	// Ensure GCC and Clang compiles with `-cstrict`
+	return unsafe { (&char(C.webui_get_string(e))).vstring() }
+}
+
+// Parse argument as boolean.
+pub fn (e &Event) bool() bool {
+	return C.webui_get_bool(e)
+}
+
+type Response = bool | i64 | int | string
+
+// Return the response to JavaScript.
+pub fn (e &Event) @return(response Response) {
+	match response {
+		int {
+			C.webui_return_int(e, i64(response))
+		}
+		i64 {
+			C.webui_return_int(e, response)
+		}
+		string {
+			C.webui_return_string(e, &char(response.str))
+		}
+		bool {
+			C.webui_return_bool(e, response)
+		}
+	}
 }

--- a/src/lib_test.v
+++ b/src/lib_test.v
@@ -37,11 +37,10 @@ fn test_v_fn_call() {
 		assert connected
 	}(timeout_ch)
 
-	w.bind('test_v_fn', fn [timeout_ch] (e &Event) Response {
+	w.bind('test_v_fn', fn [timeout_ch] (e &Event) {
 		timeout_ch <- true
-		assert e.data.string == 'foo'
+		assert e.string() == 'foo'
 		e.window.close()
-		return 0
 	})
 	wait()
 }


### PR DESCRIPTION
This is probably the most complicated change I'm going to suggest here. It is a breaking change. But the improvements hopefully outweigh this.

The PR has following changes that are related to each other
- Moves towards better utilizing the WebUI C library to bind functions. 
- Removes the need of additionally storing the callbacks in an global variable
  Usually, global variables in V are only allowed when a user passes the `-enable-global` flag. 
  Currently, this flag isn't necessary due to (mis)usage of the `[translated]` attribute. The attribute also deactivates several other functionalities and checks. Usually it's only for automatically generated C code. Resolving this reduces the potential for future breaking changes.
- Uses a void bind callback that resembles it's parent C function.
  Removes the need to add e.g. `return 0` to every bound function even when it doesn't return anything.
  If functions should return values to JS the Events return method can be used, e.g.: `e.@return(my_number)`.
- Event string-, int- and bool-data can be accessed with the new equivalent Event methods.
- Updates the bind function to return the bound Functions id instead of the window id on which the function was called on.
- Uses `usize` for `size_t` types
- Updates, cleanups and fixes spelling in examples
- Implements the new event `size` field
- Adds doc comments for public function and organizes the library
- Implements the new function to set the default root folder

Result: https://github.com/ttytm/v-webui/blob/refactor/reimpl-event-handling/src/lib.v.

It might be easiest to look at the commits separately to follow the changes. It's a lot so sorry about the headache. I hope you find your way trough and please let me know if something is unclear or should be changed.
