### PR TITLE
Update build flags to latest changes

### DIFF
--- a/setup.vsh
+++ b/setup.vsh
@@ -63,7 +63,7 @@ fn build() ! {
 	mut p := new_process(cmd)
 	p.set_work_folder(build_dir)
 	p.wait()
-	required := 'libwebui-2-static-x64.a'
+	required := 'libwebui-2-static.a'
 	if !exists('${build_dir}/dist/${required}') {
 		return error('Failed building WebUI. Can\'t find required build output ${required}')
 	}

--- a/src/lib.c.v
+++ b/src/lib.c.v
@@ -2,8 +2,10 @@ module vwebui
 
 #include "@VMODROOT/webui/webui.h"
 
-#flag -L@VMODROOT/webui -lwebui-2-static-x64 -lpthread -lm
-#flag windows @VMODROOT/webui/webui-2-x64.dll -lws2_32
+#flag -L@VMODROOT/webui -lwebui-2-static
+#flag linux -lpthread -lm
+#flag darwin -lpthread -lm
+#flag windows -lwebui-2 -lws2_32
 
 struct C.webui_event_t {
 pub:


### PR DESCRIPTION
Keeps things up to date after: https://github.com/webui-dev/webui/pull/168. Better structures platform flags.

Fails until upstream is merged.

Re-running `./setup.v` will be required.