### PR TITLE
Make script function safer and simpler to use

### DIFF
--- a/examples/call_js_from_v.v
+++ b/examples/call_js_from_v.v
@@ -1,15 +1,5 @@
 import vwebui as ui
 
-fn my_function_count(e &ui.Event) {
-	count := e.window.script('return count;', 0, 48)
-	e.window.script('SetCount(${count.int() + 1});', 0, 0)
-}
-
-// Close all opened windows
-fn my_function_exit(e &ui.Event) {
-	ui.exit()
-}
-
 // UI HTML
 const doc = '<!DOCTYPE html>
 <html>
@@ -44,16 +34,27 @@ const doc = '<!DOCTYPE html>
 	</body>
 </html>'
 
+fn my_function_count(e &ui.Event) {
+	count := e.window.script('return count;')
+	dump(count.success)
+	e.window.script('SetCount(${count.output.int() + 1});')
+}
+
+// Close all opened windows
+fn my_function_exit(e &ui.Event) {
+	ui.exit()
+}
+
 // Create a window
 mut w := ui.new_window()
 
-// Bind HTML elements with functions
+// Bind HTML elements to functions
 w.bind('MyButton1', my_function_count)
 w.bind('MyButton2', my_function_exit)
 
-// Show the window
-if !w.show(doc) { // Run the window
-	panic('The browser(s) was failed') // If not, print a error info
+// Show the window, panic on fail
+if !w.show(doc) {
+	panic('The browser(s) was failed')
 }
 
 // Wait until all windows get closed

--- a/examples/simple_example.v
+++ b/examples/simple_example.v
@@ -26,11 +26,10 @@ const doc = '<!DOCTYPE html>
 </html>'
 
 fn check_the_password(e &ui.Event) {
-	password := e.window.script('return document.getElementById("MyInput").value;', 0,
-		4096)
-	println('Password: ' + password)
+	res := e.window.script('return document.getElementById("MyInput").value;')
+	println('Password: ' + res.output)
 
-	if password == '123456' {
+	if res.output == '123456' {
 		e.window.run("alert('Good. Password is correct.');")
 	} else {
 		e.window.run("alert('Sorry. Wrong password.');")


### PR DESCRIPTION
This PR updates the script method that calls javascript and returns a response.

The current implementation strips away the simple possibility of the parent C API to check if the script has run successfully.

It re-implemets this possibility for the `script` method and makes it safer and simpler to use.
- The only arguments for the method will be the java script code string
- The params `timeout` and the response buffer size `max_response_size` (defaults to 8KiB) become optional.
  ```v
  // New default
  resp := e.window.script('return count;')
  // Instead of default
  resp := e.window.script('return count;', 0, 4096)
  // Now, if a timeout should be added
  resp := e.window.script('return count;', timeout: 10)
  ```
- It will return a `ScriptResponse` inspired by Vs builtin `os.execute`.
  This contains a `success` and a `output` filed. It can be used with e.g. `resp.success` to check if it the script has run successfully and `res.ouput` to get the output.