### PR TITLE
Endorse error handling by default

### DIFF
--- a/examples/call_js_from_v.v
+++ b/examples/call_js_from_v.v
@@ -6,16 +6,16 @@ const doc = '<!DOCTYPE html>
 	<head>
 	<title>Call JavaScript from V Example</title>
 	<style>
-	body {
-		background: linear-gradient(to left, #36265a, #654da9);
-		color: AliceBlue;
-		font: 16px sans-serif;
-		text-align: center;
-		margin-top: 30px;
-	}
-	button {
-		margin: 5px 0 10px;
-	}
+		body {
+			background: linear-gradient(to left, #36265a, #654da9);
+			color: AliceBlue;
+			font: 16px sans-serif;
+			text-align: center;
+			margin-top: 30px;
+		}
+		button {
+			margin: 5px 0 10px;
+		}
 	</style>
 	</head>
 	<body>
@@ -35,11 +35,8 @@ const doc = '<!DOCTYPE html>
 </html>'
 
 fn my_function_count(e &ui.Event) {
-	res := e.window.script('return count;')
-	if !res.success {
-		return
-	}
-	e.window.run('SetCount(${res.output.int() + 1});')
+	count := e.window.script('return count;') or { return }
+	e.window.run('SetCount(${count.int() + 1});')
 }
 
 // Close all opened windows
@@ -55,9 +52,7 @@ w.bind('MyButton1', my_function_count)
 w.bind('MyButton2', my_function_exit)
 
 // Show the window, panic on fail
-if !w.show(doc) {
-	panic('The browser(s) was failed')
-}
+w.show(doc) or { panic(err) }
 
 // Wait until all windows get closed
 ui.wait()

--- a/examples/call_v_from_js.v
+++ b/examples/call_v_from_js.v
@@ -82,9 +82,8 @@ doc := '<!DOCTYPE html>
 
 mut w := ui.new_window() // Create a window
 
-if !w.show(doc) { // Run the window
-	panic('The browser(s) was failed') // If not, print a error info
-}
+// Show the window, panic on fail
+w.show(doc) or { panic(err) }
 
 w.bind('MyID_One', my_function_string)
 w.bind('MyID_Two', my_function_integer)

--- a/examples/kiosk.v
+++ b/examples/kiosk.v
@@ -19,5 +19,5 @@ w.show('<!DOCTYPE html>
 	<body>
 		<h1>WebUI - Kiosk Example</h1>
 	</body>
-</html>')
+</html>') or {}
 ui.wait()

--- a/examples/minimal.v
+++ b/examples/minimal.v
@@ -1,5 +1,5 @@
 import vwebui as ui
 
 mut w := ui.new_window()
-w.show('<html>Hello</html>')
+w.show('<html>Hello</html>') or {}
 ui.wait()

--- a/examples/serve_a_folder/main.v
+++ b/examples/serve_a_folder/main.v
@@ -20,11 +20,11 @@ fn events(e &ui.Event) {
 
 // Switch to `/second.html` in the same opened window.
 fn switch_to_second_page(e &ui.Event) {
-	e.window.show('second.html')
+	e.window.show('second.html') or { eprintln(err) }
 }
 
 fn show_second_window(e &ui.Event) {
-	w2.show('second.html')
+	w2.show('second.html') or { eprintln(err) }
 }
 
 fn exit_app(e &ui.Event) {
@@ -38,7 +38,7 @@ fn main() {
 	w.bind('OpenNewWindow', show_second_window)
 	w.bind('Exit', exit_app)
 	w.bind('', events) // Bind events
-	w.show('index.html') // Show a new window
+	w.show('index.html') or { panic(err) } // Show a new window
 
 	w2.new_window()
 	w2.bind('Exit', exit_app)

--- a/examples/simple_example.v
+++ b/examples/simple_example.v
@@ -26,10 +26,13 @@ const doc = '<!DOCTYPE html>
 </html>'
 
 fn check_the_password(e &ui.Event) {
-	res := e.window.script('return document.getElementById("MyInput").value;')
-	println('Password: ' + res.output)
+	password := e.window.script('return document.getElementById("MyInput").value;') or {
+		eprintln(err)
+		return
+	}
+	println('Password: ' + password)
 
-	if res.output == '123456' {
+	if password == '123456' {
 		e.window.run("alert('Good. Password is correct.');")
 	} else {
 		e.window.run("alert('Sorry. Wrong password.');")
@@ -49,9 +52,7 @@ w.bind('MyButton1', check_the_password)
 w.bind('MyButton2', close_the_application)
 
 // Show the window, panic on fail
-if !w.show(doc) {
-	panic('Failed showing window.')
-}
+w.show(doc) or { panic(err) }
 
 // Wait until all windows get closed
 ui.wait()

--- a/examples/text-editor/main.v
+++ b/examples/text-editor/main.v
@@ -51,7 +51,7 @@ fn main() {
 	w.bind('Open', open)
 	w.bind('Save', save)
 	w.bind('Close', close)
-	w.show('ui/MainWindow.html')
+	w.show('ui/MainWindow.html') or { panic(err) }
 
 	ui.wait()
 }

--- a/src/lib_test.v
+++ b/src/lib_test.v
@@ -6,8 +6,7 @@ fn test_window_close() {
 
 	// Wait for the window to show
 	ui.set_timeout(30)
-	if !w.show('<html style="background: #654da9; color: #eee"><samp>test_window_close</samp></html>') {
-		eprintln('Failed showing window.')
+	w.show('<html style="background: #654da9; color: #eee"><samp>test_window_close</samp></html>') or {
 		assert false
 	}
 	for i in 0 .. 30 {
@@ -40,7 +39,7 @@ fn test_fn_call() {
 
 	w.bind('v_fn', fn (e &ui.Event) {
 		assert e.string() == 'foo'
-		// Call a js fuction that should calls another V function.
+		// Call a JS fuction that calls another V function.
 		e.window.run('await callV();')
 	})
 	w.bind('v_fn_with_obj_arg', fn (e &ui.Event) {
@@ -55,7 +54,7 @@ fn test_fn_call() {
 		e.window.close()
 	})
 
-	if !w.show('<html style="background: #654da9; color: #eee">
+	w.show('<html style="background: #654da9; color: #eee">
 <body>
 	<samp>test_fn_call</samp>
 	<script>
@@ -71,8 +70,7 @@ fn test_fn_call() {
 		}
 	</script>
 </body>
-</html>') {
-		eprintln('Failed showing window.')
+</html>') or {
 		assert false
 	}
 


### PR DESCRIPTION
The proposal utilizes V's function result returns for the wrapping of the C functions that return a boolean that resembles if the function was successfully called.

E.g. a function that might fail, could handle the error simpler and would have to ignore it explicitly.

Current:
```v
// Handle error example:
// Show the window, panic on fail
if !w.show(doc) {
	panic('The browser(s) was failed')
}

// Ignore error:
// Without using the bool return it isn't clear that the function could fail.
w.show() 
```

Proposed:
```v
/// Handle error example:
// Show the window, panic on fail
w.show(doc) or { panic(err) }

// Ignore error:
w.show(doc) or {}
```

I think this is a more V native way to handle functions that can fail and would endorse error handling by default and better safety.




