### PR TITLE
Use platform dependent commands to move build outputs to module dir

### DIFF
--- a/setup.vsh
+++ b/setup.vsh
@@ -70,12 +70,18 @@ fn build() ! {
 }
 
 fn move() ! {
-	// The using `os.mv` steps currently turns out saver than e.g., especially on Windows
-	// execute('mv ${lib_dir}/dist/ ./dist/ && mv ${lib_dir}/include/* ./dist/')
 	chdir(build_dir)!
-	mv('include/webui.h', 'dist/webui.h')!
-	mv('include/webui.hpp', 'dist/webui.hpp')!
-	mv('dist/', lib_dir)!
+	$if windows {
+		// Using single `os.mv` steps turns out saver on Windows
+		mv('include/webui.h', 'dist/webui.h')!
+		mv('include/webui.hpp', 'dist/webui.hpp')!
+		mv('dist/', lib_dir)!
+	} $else {
+		res := os.execute('mv include/webui.* dist/ && mv dist/ ${lib_dir}/')
+		if res.exit_code != 0 {
+			return error('Failed moving WebUI build output to ${lib_dir}. ${res.output}')
+		}
+	}
 }
 
 fn run(cmd cli.Command) ! {


### PR DESCRIPTION
I'm running into some issues running the setup script on a linux machine. The isse happens when trying to move the build outputs from the temp into the module directory.

```
cli execution error: cp (permission): failed to write to /home/t/.vmodules/vwebui/webui/ (fp_to: -1)
```

So I would just add a platform condition to use the commands that work for the platforms.