### PR TITLE
Use shorthand error propagation

### DIFF
--- a/examples/kiosk.v
+++ b/examples/kiosk.v
@@ -21,5 +21,5 @@ w.show('<!DOCTYPE html>
 	<body>
 		<h1>WebUI - Kiosk Example</h1>
 	</body>
-</html>') or {}
+</html>')!
 ui.wait()

--- a/examples/minimal.v
+++ b/examples/minimal.v
@@ -1,5 +1,5 @@
 import vwebui as ui
 
 mut w := ui.new_window()
-w.show('<html><head><script src="/webui.js"></script></head>Hello</html>') or {}
+w.show('<html><head><script src="/webui.js"></script></head>Hello</html>')!
 ui.wait()

--- a/examples/serve_a_folder/main.v
+++ b/examples/serve_a_folder/main.v
@@ -38,7 +38,7 @@ fn main() {
 	w.bind('OpenNewWindow', show_second_window)
 	w.bind('Exit', exit_app)
 	w.bind('', events) // Bind events
-	w.show('index.html') or { panic(err) } // Show a new window
+	w.show('index.html')! // Show a new window
 
 	w2.new_window()
 	w2.bind('Exit', exit_app)


### PR DESCRIPTION
A minor refactor of the examples that don't explicitly mention a panic on fail error handling. Better style than ignoring I think, and even shorter for the minimal example.