### PR TITLE
Add generic returns for bind callback for improved type safety

### DIFF
--- a/examples/call_js_from_v.v
+++ b/examples/call_js_from_v.v
@@ -36,9 +36,10 @@ const doc = '<!DOCTYPE html>
 	</body>
 </html>'
 
-fn my_function_count(e &ui.Event) {
-	count := e.window.script('return count;') or { return }
+fn my_function_count(e &ui.Event) voidptr {
+	count := e.window.script('return count;') or { return ui.no_result }
 	e.window.run('SetCount(${count.int() + 1});')
+	return ui.no_result
 }
 
 // Close all opened windows
@@ -51,7 +52,9 @@ mut w := ui.new_window()
 
 // Bind HTML elements to functions
 w.bind('MyButton1', my_function_count)
-w.bind('MyButton2', my_function_exit)
+// Alternative way to bind a function that does not return a value to JS
+// and omits the return in the function body.
+w.bind[voidptr]('MyButton2', my_function_exit)
 
 // Show the window, panic on fail
 w.show(doc) or { panic(err) }

--- a/examples/call_v_from_js.v
+++ b/examples/call_v_from_js.v
@@ -1,44 +1,6 @@
 import vwebui as ui
 
-fn my_function_string(e &ui.Event) {
-	// JavaScript:
-	// webui.call('MyID_One', 'Hello');
-
-	response := e.string()
-	println('my_function_string: ${response}') // Hello
-
-	// Need Multiple Arguments?
-	//
-	// WebUI support only one argument. To get multiple arguments
-	// you can send a JSON string from JavaScript then decode it.
-}
-
-fn my_function_integer(e &ui.Event) {
-	// JavaScript:
-	// webui.call('MyID_Two', 123456789);
-
-	response := e.int()
-	println('my_function_integer: ${response}') // 123456789
-}
-
-fn my_function_boolean(e &ui.Event) {
-	// JavaScript:
-	// webui.call('MyID_Three', true);
-
-	response := e.bool()
-	println('my_function_boolean: ${response}') // true
-}
-
-fn my_function_with_response(e &ui.Event) {
-	// JavaScript:
-	// const result = webui.call('MyID_Four', number);
-
-	number := e.int() * 2
-	println('my_function_with_response: ${number}')
-	e.@return(number)
-}
-
-doc := '<!DOCTYPE html>
+const doc = '<!DOCTYPE html>
 <html>
 	<head>
 		<title>Call V from JavaScript Example</title>
@@ -71,16 +33,56 @@ doc := '<!DOCTYPE html>
 		<button onclick="MyJS();">Call my_function_with_response()</button>
 		<div>Double: <input type="text" id="MyInputID" value="2"></div>
 		<script>
-			function MyJS() {
+			async function MyJS() {
 				const MyInput = document.getElementById("MyInputID");
 				const number = MyInput.value;
-				webui.call("MyID_Four", number).then((response) => {
-						MyInput.value = response;
-				});
+				const result = await webui.call("MyID_Four", number);
+				MyInput.value = result;
 			}
 		</script>
 	</body>
 </html>'
+
+// JavaScript:
+// webui.call('MyID_One', 'Hello');
+fn my_function_string(e &ui.Event) voidptr {
+	response := e.string()
+	println('my_function_string: ${response}') // Hello
+
+	// Need Multiple Arguments?
+	//
+	// WebUI supports only one argument. For multiple arguments,
+	// send a JSON string from JavaScript and decode it.
+
+	return ui.no_result
+}
+
+// JavaScript:
+// webui.call('MyID_Two', 123456789);
+fn my_function_integer(e &ui.Event) voidptr {
+	response := e.int()
+	println('my_function_integer: ${response}') // 123456789
+
+	return ui.no_result
+}
+
+// JavaScript:
+// webui.call('MyID_Three', true);
+fn my_function_boolean(e &ui.Event) voidptr {
+	response := e.bool()
+	println('my_function_boolean: ${response}') // true
+
+	return ui.no_result
+}
+
+// JavaScript:
+// const result = webui.call('MyID_Four', number);
+fn my_function_with_response(e &ui.Event) int {
+	number := e.int() * 2
+	println('my_function_with_response: ${number}')
+
+	return number
+}
 
 mut w := ui.new_window() // Create a window
 

--- a/examples/serve_a_folder/main.v
+++ b/examples/serve_a_folder/main.v
@@ -34,14 +34,14 @@ fn exit_app(e &ui.Event) {
 fn main() {
 	w.new_window()
 
-	w.bind('SwitchToSecondPage', switch_to_second_page)
-	w.bind('OpenNewWindow', show_second_window)
-	w.bind('Exit', exit_app)
-	w.bind('', events) // Bind events
+	w.bind[voidptr]('SwitchToSecondPage', switch_to_second_page)
+	w.bind[voidptr]('OpenNewWindow', show_second_window)
+	w.bind[voidptr]('Exit', exit_app)
+	w.bind[voidptr]('', events) // Bind events
 	w.show('index.html')! // Show a new window
 
 	w2.new_window()
-	w2.bind('Exit', exit_app)
+	w2.bind[voidptr]('Exit', exit_app)
 
 	ui.set_root_folder(@VMODROOT)
 	ui.wait() // Wait until all windows get closed

--- a/examples/simple_example.v
+++ b/examples/simple_example.v
@@ -26,10 +26,10 @@ const doc = '<!DOCTYPE html>
 	</body>
 </html>'
 
-fn check_the_password(e &ui.Event) {
+fn check_the_password(e &ui.Event) voidptr {
 	password := e.window.script('return document.getElementById("MyInput").value;') or {
 		eprintln(err)
-		return
+		return ui.no_result
 	}
 	println('Password: ' + password)
 
@@ -38,11 +38,13 @@ fn check_the_password(e &ui.Event) {
 	} else {
 		e.window.run("alert('Sorry. Wrong password.');")
 	}
+	return ui.no_result
 }
 
 // Close all opened windows
-fn close_the_application(e &ui.Event) {
+fn close_the_application(e &ui.Event) voidptr {
 	ui.exit()
+	return ui.no_result
 }
 
 // Create a window

--- a/examples/text-editor/main.v
+++ b/examples/text-editor/main.v
@@ -48,9 +48,9 @@ fn main() {
 
 	w.set_root_folder(@VMODROOT)
 
-	w.bind('Open', open)
-	w.bind('Save', save)
-	w.bind('Close', close)
+	w.bind[voidptr]('Open', open)
+	w.bind[voidptr]('Save', save)
+	w.bind[voidptr]('Close', close)
 	w.show('ui/index.html') or { panic(err) }
 
 	ui.wait()

--- a/src/lib.v
+++ b/src/lib.v
@@ -200,23 +200,18 @@ pub fn (e Event) decode[T]() !T {
 	return json.decode(T, e.string()) or { return error('Failed decoding arguments. `${err}`') }
 }
 
-type Response = bool | i64 | int | string
-
 // Return the response to JavaScript.
-pub fn (e &Event) @return(response Response) {
-	match response {
-		int {
-			C.webui_return_int(e, i64(response))
-		}
-		i64 {
-			C.webui_return_int(e, response)
-		}
-		string {
-			C.webui_return_string(e, &char(response.str))
-		}
-		bool {
-			C.webui_return_bool(e, response)
-		}
+pub fn (e &Event) @return[T](response T) {
+	$if response is int {
+		C.webui_return_int(e, i64(response))
+	} $else $if response is i64 {
+		C.webui_return_int(e, response)
+	} $else $if response is string {
+		C.webui_return_string(e, &char(response.str))
+	} $else $if response is bool {
+		C.webui_return_bool(e, response)
+	} $else $if response !is voidptr {
+		C.webui_return_string(e, json.encode(response).str)
 	}
 }
 

--- a/tests/thread_gc_test.v
+++ b/tests/thread_gc_test.v
@@ -40,7 +40,7 @@ fn test_thread_gc() {
 		w.destroy()
 	}
 
-	w.bind('v_fn', fn [mut app] (e &ui.Event) {
+	w.bind[voidptr]('v_fn', fn [mut app] (e &ui.Event) {
 		log.info('>>> v_fn called')
 		defer {
 			log.info('>>> v_fn ended')


### PR DESCRIPTION
This change should add a safe implementation of typed return values for bind callbacks. I think with solution found here, bringing back the feature makes sense as it is safely implemented and also facilities safer code.

Bind callbacks can specify any return value and the type checker will assists to ensure the correct type is returned in functions body.

```v
fn my_fn(e &ui.Event) string {
	str := 'hello'
	return str
} 
w.bind('my_fn', my_fn)
```

With this change comes with a feature of automatically json-encoding types that are not strings, ints or bools. E.g.:

```v
w.bind('v_fn_with_struct_return', fn (e &ui.Event) Person {
	p := Person{name:'bob', age: 30}
	return p // JS will receive a JSON encoded object
}
```

The default types continue to use their equivalent webui_return functions like `webui_return_int`. It uses a generic closure and evaluates return types at comptime. So it adds no runtime overhead. 
```v
// lib internal return function
fn (e &Event) @return[T](response T) {
	$if response is int {
		C.webui_return_int(e, i64(response))
	} $else $if response is i64 {
		C.webui_return_int(e, response)
	} $else $if response is string {
		C.webui_return_string(e, &char(response.str))
	} $else $if response is bool {
		C.webui_return_bool(e, response)
	} $else $if response !is voidptr {
		C.webui_return_string(e, json.encode(response).str)
	}
}
```

Functions with void returns can be used in two ways
1. using the `no_result` const, which is inspired by same usage of `no_result` in Vs pool processor module https://modules.vlang.io/sync.pool.html#Constants, https://github.com/vlang/v/blob/5d1f87c5aa0342eb5b492d1c15d1b2411823ccb7/examples/news_fetcher.v#L13-L25
```v
fn exit(e &ui.Event) voidptr {
	ui.exit()
	return ui.no_result
}
w.bind('exit', exit)
```

2. Or with `bind[voidptr]` and omitting the return in the function body
```v
fn exit(e &ui.Event) {
	ui.exit()
}
w.bind[voidptr]('exit', exit)
```



Changes are organized into commits.

