### PR TITLE
Update setup script to download WebUI Github releases

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup WebUI Library
         shell: bash
         run: |
-          v -d ci run ${{ env.MOD_NAME }}/setup.vsh
+          v run ${{ env.MOD_NAME }}/setup.vsh
           mv ${{ env.MOD_NAME }} ~/.vmodules/${{ env.MOD_NAME }}
       - name: Cache
         uses: actions/cache/save@v3

--- a/setup.vsh
+++ b/setup.vsh
@@ -2,88 +2,71 @@
 
 import cli
 import os
+import v.pref
+import net.http
 
 const (
-	lib_url   = 'https://github.com/webui-dev/webui'
-	lib_dir   = os.join_path(@VMODROOT, 'webui')
-	build_dir = $if ci ? {
-		lib_dir + '_tmp'
-	} $else {
-		os.join_path(os.temp_dir(), 'webui')
+	platform = pref.get_host_os()
+	arch     = pref.get_host_arch()
+	base_url = 'https://github.com/webui-dev/webui/releases/'
+	archives = {
+		'Linux':   {
+			'amd64': 'webui-linux-gcc-x64.tar.gz'
+		}
+		'MacOS':   {
+			'amd64': 'webui-macos-clang-x64.tar.gz'
+			'arm64': 'webui-macos-clang-arm64.tar.gz'
+		}
+		'Windows': {
+			'amd64': 'webui-windows-gcc-x64.zip'
+		}
 	}
 )
 
-fn clean() {
-	// Remove old library files
-	$if windows {
-		execute('rd /s /q ${build_dir}')
-		execute('rd /s /q ${lib_dir}')
-	} $else {
-		rmdir_all(build_dir) or {}
-		rmdir_all(lib_dir) or {}
-	}
-}
-
-fn which(cmd string) !string {
-	$if windows {
-		paths := execute('where ${cmd}').output.trim_space().split_into_lines()
-		for p in paths {
-			if p.contains(cmd) {
-				return p
-			}
-		}
-	} $else {
-		path := execute('which ${cmd}').output.trim_space()
-		if path != '' {
-			return path
-		}
-	}
-	return error('Failed finding make command.')
-}
-
-fn get() ! {
-	clone_cmd := 'git clone --depth 1 ${lib_url}'
-	println('Cloning...')
-	println(clone_cmd)
-	clone_res := execute('${clone_cmd} ${build_dir}')
-	if clone_res.exit_code != 0 {
-		return error('Failed cloning WebUI. ${clone_res.output}')
-	}
-}
-
-fn build() ! {
-	build_cmd := $if windows { 'mingw32-make' } $else { 'make' }
-	println('\nBuilding...')
-	cmd := which(build_cmd)!
-	mut p := new_process(cmd)
-	p.set_work_folder(build_dir)
-	p.wait()
-	required := 'libwebui-2-static.a'
-	if !exists('${build_dir}/dist/${required}') {
-		return error('Failed building WebUI. Can\'t find required build output ${required}')
-	}
-}
-
-fn move() ! {
-	chdir(build_dir)!
-	$if windows {
-		// Using single `os.mv` steps turns out saver on Windows
-		mv('include/webui.h', 'dist/webui.h')!
-		mv('include/webui.hpp', 'dist/webui.hpp')!
-		mv('dist/', lib_dir)!
-	} $else {
-		res := os.execute('mv include/webui.* dist/ && mv dist/ ${lib_dir}/')
-		if res.exit_code != 0 {
-			return error('Failed moving WebUI build output to ${lib_dir}. ${res.output}')
-		}
-	}
-}
-
 fn run(cmd cli.Command) ! {
-	clean()
-	get()!
-	build()!
-	move()!
+	out_dir := cmd.flags.get_string('output')!
+	nightly := cmd.flags.get_bool('nightly')!
+
+	// Remove old library files.
+	// TODO: remove that wit certainty are WebUI files instead of full dir.
+	$if windows {
+		// During tests, `rmdir_all` on Windows could run into permission errors.
+		execute('rd /s /q ${out_dir}')
+	} $else {
+		rmdir_all(out_dir) or {}
+	}
+
+	archive := archives[platform.str()] or {
+		return error('The setup script currently does not support `${platform}`.')
+	}[arch.str()] or {
+		return error('The setup script currently does not support `${arch}` architectures.')
+	}
+
+	println('Downloading...')
+	url := base_url + if nightly { 'download/nightly/' } else { 'latest/download/' }
+	http.download_file(url + archive, archive) or {
+		return error('Failed downloading archive `${archive}`. ${err}')
+	}
+
+	println('Extracting...')
+	$if windows {
+		unzip_res := execute('powershell -command Expand-Archive -LiteralPath ${archive}')
+		if unzip_res.exit_code != 0 {
+			return error('Failed extracting archive `${archive}`. ${unzip_res.output}')
+		}
+		dir := archive.all_before('.zip')
+		mv(join_path(dir, dir), out_dir)!
+		rmdir(dir)!
+	} $else {
+		unzip_res := execute('tar -xvzf ${archive}')
+		if unzip_res.exit_code != 0 {
+			return error('Failed extracting archive `${archive}`. ${unzip_res.output}')
+		}
+		mv(archive.all_before('.tar'), out_dir)!
+	}
+	rm(archive)!
+
+	println('Done.')
 }
 
 mut cmd := cli.Command{
@@ -97,6 +80,23 @@ mut cmd := cli.Command{
 			exit(0)
 		}
 	}
+	flags: [
+		cli.Flag{
+			flag: .string
+			name: 'output'
+			abbrev: 'o'
+			description: 'Specify the output path for the download WebUI platfrom release.'
+			global: true
+			default_value: [join_path(@VMODROOT, 'webui')]
+		},
+		cli.Flag{
+			flag: .bool
+			name: 'nightly'
+			description: 'Download the nightly version instead of the latest stable version.'
+			global: true
+			default_value: ['true'] // Remove after WebUI v2.4.0 was released
+		},
+	]
 	execute: run
 }
 cmd.parse(os.args)

--- a/src/lib.c.v
+++ b/src/lib.c.v
@@ -1,6 +1,12 @@
 module vwebui
 
-#include "@VMODROOT/webui/webui.h"
+#include "@VMODROOT/webui/include/webui.h"
+
+$if webui_log ? {
+	#flag -L@VMODROOT/webui/debug -lwebui-2-static
+} $else {
+	#flag -L@VMODROOT/webui -lwebui-2-static
+}
 
 #flag -L@VMODROOT/webui -lwebui-2-static
 #flag linux -lpthread -lm


### PR DESCRIPTION
Closes #59

Currently it uses WebUIs nightly releases.

Eventually (for the 2.4.0 release), it will be updated to to download the stable releases by default and optionally nightly releases.

@hassandraga we could make this into a repo (something like webui-release-downloader). It could have its own binary GitHub releases and work as CLI tool that other wrappers could download and use to download and prepare the WebUI static files for different platforms. It would help to keep things uniform. I would make the webui destination dir configurable via an argument then.
