### PR TITLE
Refactor get args

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,12 +36,9 @@ target/
 nul
 
 # Binary files
-lib_test
 main
-minimal
-simple_example
-kiosk
-call_v_from_js
-call_js_from_v
-serve_a_folder
-text-editor
+examples/minimal
+examples/call_v_from_js
+examples/call_js_from_v
+examples/serve_a_folder/serve_a_folder
+examples/text-editor/text-editor

--- a/examples/call_js_from_v.v
+++ b/examples/call_js_from_v.v
@@ -41,22 +41,22 @@ fn my_function_count(e &ui.Event) voidptr {
 	return ui.no_result
 }
 
-// Close all opened windows
+// Close all opened windows.
 fn my_function_exit(e &ui.Event) {
 	ui.exit()
 }
 
-// Create a window
+// Create a window.
 mut w := ui.new_window()
 
-// Bind HTML elements to functions
+// Bind HTML elements to functions.
 w.bind('MyButton1', my_function_count)
 // Alternative way to bind a function that does not return a value to JS
 // and omits the return in the function body.
 w.bind[voidptr]('MyButton2', my_function_exit)
 
-// Show the window, panic on fail
-w.show(doc) or { panic(err) }
+// Show the window, panic on fail.
+w.show(doc)!
 
-// Wait until all windows get closed
+// Wait until all windows get closed.
 ui.wait()

--- a/examples/call_v_from_js.v
+++ b/examples/call_v_from_js.v
@@ -45,7 +45,7 @@ const doc = '<!DOCTYPE html>
 // JavaScript:
 // webui.call('MyID_One', 'Hello');
 fn my_function_string(e &ui.Event) voidptr {
-	response := e.string()
+	response := e.get_arg[string]() or { return ui.no_result }
 	println('my_function_string: ${response}') // Hello
 
 	// Need Multiple Arguments?
@@ -59,7 +59,7 @@ fn my_function_string(e &ui.Event) voidptr {
 // JavaScript:
 // webui.call('MyID_Two', 123456789);
 fn my_function_integer(e &ui.Event) voidptr {
-	response := e.int()
+	response := e.get_arg[int]() or { return ui.no_result }
 	println('my_function_integer: ${response}') // 123456789
 
 	return ui.no_result
@@ -68,7 +68,7 @@ fn my_function_integer(e &ui.Event) voidptr {
 // JavaScript:
 // webui.call('MyID_Three', true);
 fn my_function_boolean(e &ui.Event) voidptr {
-	response := e.bool()
+	response := e.get_arg[bool]() or { return ui.no_result }
 	println('my_function_boolean: ${response}') // true
 
 	return ui.no_result
@@ -77,21 +77,22 @@ fn my_function_boolean(e &ui.Event) voidptr {
 // JavaScript:
 // const result = webui.call('MyID_Four', number);
 fn my_function_with_response(e &ui.Event) int {
-	number := e.int() * 2
+	number := e.get_arg[int]() or { return 0 } * 2
 	println('my_function_with_response: ${number}')
 
 	return number
 }
 
-mut w := ui.new_window() // Create a window
+// Create a window.
+mut w := ui.new_window()
 
-// Show the window, panic on fail
-w.show(doc) or { panic(err) }
+// Show the window, panic on fail.
+w.show(doc)!
 
 w.bind('MyID_One', my_function_string)
 w.bind('MyID_Two', my_function_integer)
 w.bind('MyID_Three', my_function_boolean)
 w.bind('MyID_Four', my_function_with_response)
 
-// Wait until all windows get closed
+// Wait until all windows get closed.
 ui.wait()

--- a/examples/serve_a_folder/main.v
+++ b/examples/serve_a_folder/main.v
@@ -5,7 +5,7 @@ const (
 	w2 = ui.Window(2)
 )
 
-// This function gets called every time there is an event
+// This function gets called every time there is an event.
 fn events(e &ui.Event) {
 	if e.event_type == .connected {
 		println('Connected.')
@@ -14,7 +14,7 @@ fn events(e &ui.Event) {
 	} else if e.event_type == .mouse_click {
 		println('Click.')
 	} else if e.event_type == .navigation {
-		println('Starting navigation to: ${e.string()}')
+		println('Starting navigation to: ${e.get_arg[string]() or {}}')
 	}
 }
 
@@ -37,12 +37,12 @@ fn main() {
 	w.bind[voidptr]('SwitchToSecondPage', switch_to_second_page)
 	w.bind[voidptr]('OpenNewWindow', show_second_window)
 	w.bind[voidptr]('Exit', exit_app)
-	w.bind[voidptr]('', events) // Bind events
-	w.show('index.html')! // Show a new window
+	w.bind[voidptr]('', events) // Bind events.
+	w.show('index.html')! // Show a new window.
 
 	w2.new_window()
 	w2.bind[voidptr]('Exit', exit_app)
 
 	ui.set_root_folder(@VMODROOT)
-	ui.wait() // Wait until all windows get closed
+	ui.wait() // Wait until all windows get closed>
 }

--- a/examples/text-editor/main.v
+++ b/examples/text-editor/main.v
@@ -10,13 +10,12 @@ mut:
 
 fn (mut f File) open(e &ui.Event) {
 	println('Open')
-	file := e.string()
-	if file == '' {
+	file := e.get_arg[string]() or {
 		e.window.run("webui.call('Open', prompt`File Location`)")
 		return
 	}
 	file_content := os.read_file(file) or {
-		println('Failed reading file: ${file}')
+		eprintln('Failed to read file: ${file}')
 		return
 	}
 	f_name := file.all_after_last(os.path_separator)
@@ -28,10 +27,7 @@ fn (mut f File) open(e &ui.Event) {
 
 fn (f &File) save(e &ui.Event) {
 	println('Save')
-	content := e.string()
-	if content == '' {
-		return
-	}
+	content := e.get_arg[string]() or { return }
 	os.write_file(f.path, content) or {
 		eprintln(err)
 		return

--- a/src/lib.v
+++ b/src/lib.v
@@ -193,30 +193,25 @@ pub fn (w Window) set_runtime(runtime Runtime) {
 	C.webui_set_runtime(w, runtime)
 }
 
-// int parses the JavaScript argument as integer.
-pub fn (e &Event) int() int {
-	return int(C.webui_get_int(e))
-}
-
-// i64 parses the JavaScript argument as integer.
-pub fn (e &Event) i64() i64 {
-	return C.webui_get_int(e)
-}
-
-// string parses the JavaScript argument as integer.
-pub fn (e &Event) string() string {
-	// Ensure GCC and Clang compiles with `-cstrict`
-	return unsafe { (&char(C.webui_get_string(e))).vstring() }
-}
-
-// bool parses the JavaScript argument as integer.
-pub fn (e &Event) bool() bool {
-	return C.webui_get_bool(e)
-}
-
-// decode parses the JavaScript argument into a V data type.
-pub fn (e Event) decode[T]() !T {
-	return json.decode(T, e.string()) or { return error('Failed decoding arguments. `${err}`') }
+// get_arg parses the JavaScript argument into a V data type.
+pub fn (e &Event) get_arg[T]() !T {
+	if e.size == 0 {
+		element := unsafe { (&char(e.element)).vstring() }
+		return error('`${element}` did not receive a `${T.name}` argument.')
+	}
+	return $if T is int {
+		int(C.webui_get_int(e))
+	} $else $if T is i64 {
+		C.webui_get_int(e)
+	} $else $if T is string {
+		unsafe { (&char(C.webui_get_string(e))).vstring() }
+	} $else $if T is bool {
+		C.webui_get_bool(e)
+	} $else {
+		json.decode(T, (&char(C.webui_get_string(e))).vstring()) or {
+			return error('Failed decoding `${T.name}` argument. ${err}')
+		}
+	}
 }
 
 // @return returns the response to JavaScript.

--- a/tests/fn_call_test.v
+++ b/tests/fn_call_test.v
@@ -12,15 +12,19 @@ fn test_fn_call() {
 
 	// Initial function that is being called from the browser.
 	w.bind('v_fn', fn (e &ui.Event) voidptr {
-		assert e.string() == 'foo'
+		assert e.get_arg[string]() or {
+			eprintln(err)
+			assert false
+			exit(0)
+		} == 'foo'
 		// Call a JS function that calls another V function.
 		e.window.run('await callV();')
 		return ui.no_result
 	})
 	// Next V function that is called from the JS function `callV()` that is called above.
 	w.bind('v_fn_with_obj_arg', fn (e &ui.Event) Person {
-		mut p := e.decode[Person]() or {
-			eprintln('Failed decoding person. ${err}')
+		mut p := e.get_arg[Person]() or {
+			eprintln(err)
 			assert false
 			exit(0)
 		}
@@ -35,8 +39,8 @@ fn test_fn_call() {
 	// Uses the alternative generic declaration for a function with a void return value,
 	// omitting the need to add a return to the function body.
 	w.bind[voidptr]('assert_and_exit', fn (e &ui.Event) {
-		mut p := e.decode[Person]() or {
-			eprintln('Failed decoding person. ${err}')
+		mut p := e.get_arg[Person]() or {
+			eprintln(err)
 			assert false
 			exit(0)
 		}

--- a/tests/thread_gc_test.v
+++ b/tests/thread_gc_test.v
@@ -49,7 +49,11 @@ fn test_thread_gc() {
 			log.info('>>> v_fn ended')
 		}
 		allocate_lots_of_memory()
-		assert e.string() == 'foo'
+		assert e.get_arg[string]() or {
+			eprintln(err)
+			assert false
+			exit(0)
+		} == 'foo'
 		app.fn_was_called = true
 	})
 


### PR DESCRIPTION
This PR moves towards a uniform `get_arg` function for JS argument parsing for this wrapper. The main advantages is that handling of null / error values is simplified and emphasised to make code safer. The more uniform, explicit way to access JS arguments might be seen as another small advantage.

- Public functions current:
  ```v
  // int parses the JavaScript argument as integer.
  pub fn (e &Event) int() int {
  	return int(C.webui_get_int(e))
  }
  
  // i64 parses the JavaScript argument as integer.
  pub fn (e &Event) i64() i64 {
  	return C.webui_get_int(e)
  }
  
  // string parses the JavaScript argument as integer.
  pub fn (e &Event) string() string {
  	// Ensure GCC and Clang compiles with `-cstrict`
  	return unsafe { (&char(C.webui_get_string(e))).vstring() }
  }
  
  // bool parses the JavaScript argument as integer.
  pub fn (e &Event) bool() bool {
  	return C.webui_get_bool(e)
  }
  
  // decode parses the JavaScript argument into a V data type.
  pub fn (e Event) decode[T]() !T {
  	return json.decode(T, e.string()) or { return error('Failed decoding arguments. `${err}`') }
  }
  ```
- Public function after:
  ```v
  // get_arg parses the JavaScript argument into a V data type.
  pub fn (e &Event) get_arg[T]() !T {
  	if e.size == 0 {
  		element := unsafe { (&char(e.element)).vstring() }
  		return error('`${element}` did not receive a `${T.name}` argument.')
  	}
  	return $if T is int {
  		int(C.webui_get_int(e))
  	} $else $if T is i64 {
  		C.webui_get_int(e)
  	} $else $if T is string {
  		unsafe { (&char(C.webui_get_string(e))).vstring() }
  	} $else $if T is bool {
  		C.webui_get_bool(e)
  	} $else {
  		json.decode(T, arg) or { return error('Failed decoding `${T.name}` argument. ${err}') }
  	}
  }
  ```

The text-editor examples `open` function can be used to represent the advantages of the added result return in a real application.

- `open` function current. It's not guaranteed that the programmer validates the arg and checks for null values (refinements to the current state are omitted, as the function still represents manual null handling):
  ```v
  fn open(e &ui.Event) {
  	str := e.string()
  	if str == '' {
  		e.window.run("webui.call('Open', prompt`File Location`)")
  		return
  	} else if str == 'null' {
  		return
  	}
  	file := e.string()
  	if file != '' {
  		file_content := os.read_file(file) or {
  			println('Failed to read file: ${file}')
  			''
  		}
  
  		encoded_file := base64.encode_str(file)
  		encoded_file_content := base64.encode_str(file_content)
  		e.window.run('SetFile`${encoded_file}`')
  		e.window.run('addText`${encoded_file_content}`')
  		e.window.run('window.opened_file = `${file}`')
  	}
  }
  ```

- `open` function after:
  ```v
  fn open(e &ui.Event) {
  	file := e.get_arg[string]() or {
  		e.window.run("webui.call('Open', prompt`File Location`)")
  		return
  	}
  	file_content := os.read_file(file) or {
  		eprintln('Failed to read file: ${file}')
  		return
  	}
  	encoded_file := base64.encode_str(file)
  	encoded_file_content := base64.encode_str(file_content)
  	e.window.run('SetFile`${encoded_file}`')
  	e.window.run('addText`${encoded_file_content}`')
  	e.window.run('window.opened_file = `${file}`')
  }
  ```

Alternatively, we could add the `get_arg` function and keep the `string()`, `event.int()`, `event.bool()` methods to parse args with default values. But since V enables the improved saftey in a fairly simple way, disallowing the more unsafe code can be a good choice for a library. What do you think @hassandraga?
