### PR TITLE
fix: use gcc and clang on linux, disable tcc due to missing header files

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -60,11 +60,11 @@ jobs:
     needs: setup
     strategy:
       matrix:
-        compiler: [tcc, gcc, clang]
+        compiler: [gcc, clang] # [tcc, gcc, clang]
         optimization: ['', -cstrict, -prod]
-        exclude:
-          - compiler: tcc
-            optimization: -prod
+        # exclude:
+        #   - compiler: tcc
+        #     optimization: -prod
       fail-fast: false
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ v run %USERPROFILE%/.vmodules/vwebui/setup.vsh
 ```
 
 > [!TIP]
-> On Windows it is recommended to use GCC or Clang to compile a WebUI V program. TCC is currently not working due to missing header files.
-> You can use the `-cc` flag to specify a custom compiler. E.g.:
+> It is recommended to use GCC or Clang to compile a WebUI V program.
+> TCC is currently not working due to missing header files. E.g.:
 >
 > ```
 > v -cc gcc run .


### PR DESCRIPTION
Closes #75

For now, to help avoid running into the issue, updating the recommendation is the fix that I can provide.

WebUI requires header files that are not part of tcc, so it cannot be used by default.
V already uses an extended version of tcc, so V tcc might be working with WebUI in the future.
Until then, if tcc is the desired compiler, users will have to set things up manually by themselves.
